### PR TITLE
Feat/ handle 404s

### DIFF
--- a/src/modules/notFound/notFound.route.ts
+++ b/src/modules/notFound/notFound.route.ts
@@ -1,0 +1,15 @@
+import { RouteLocationNormalized, RouteRecordRaw } from 'vue-router';
+
+export const notFoundRoute: Array<RouteRecordRaw> = [
+  {
+    path: '/:pathMatch(profile|callouts)?/:pathMatch(.*)*',
+    component: () => import('./notFound.vue'),
+  },
+  {
+    path: '/:pathMatch(.*)+',
+    component: { template: '<div></div>' },
+    beforeEnter(to: RouteLocationNormalized): void {
+      window.location.href = to.fullPath;
+    },
+  },
+];

--- a/src/modules/notFound/notFound.route.ts
+++ b/src/modules/notFound/notFound.route.ts
@@ -2,7 +2,7 @@ import { RouteLocationNormalized, RouteRecordRaw } from 'vue-router';
 
 export const notFoundRoute: Array<RouteRecordRaw> = [
   {
-    path: '/:pathMatch(profile|callouts)?/:pathMatch(.*)*',
+    path: '/:path1(profile|callouts)?/:pathRest(.*)*',
     component: () => import('./notFound.vue'),
   },
   {

--- a/src/modules/notFound/notFound.vue
+++ b/src/modules/notFound/notFound.vue
@@ -1,0 +1,3 @@
+<template>
+  <h1>Not found</h1>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,9 +1,10 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
 import { informationRoute } from '../modules/information/information.route';
+import { notFoundRoute } from '../modules/notFound/notFound.route';
 
 // routes
 
-const routes: RouteRecordRaw[] = [...informationRoute];
+const routes: RouteRecordRaw[] = [...informationRoute, ...notFoundRoute];
 
 const router = createRouter({
   history: createWebHistory(),


### PR DESCRIPTION
Currently two routes are forwarded to the frontend: `/profile` and `/callouts`. This PR makes the app handle 404s that come under those routes and force a browser redirect on all other routes.

This means we can route to internal URLs that might currently only exist on the legacy app. (e.g. `/login`).

The caveat is under local development most 404s will create an infinite redirect loop as there is no [beabee-router](https://github.com/beabee-communityrm/beabee-router) locally, but `/api` and `/login` are being proxied which is all that we need in any case.