### PR TITLE
fix: logo changes size in old browsers

### DIFF
--- a/src/modules/join/components/JoinHeader.vue
+++ b/src/modules/join/components/JoinHeader.vue
@@ -4,7 +4,7 @@
       <img
         src="../../../assets/images/logo.png"
         alt="Logo"
-        class="w-16 self-start"
+        class="w-16 flex-none self-start"
       />
       <div class="flex flex-col ml-4">
         <h1 class="font-semibold text-2xl">


### PR DESCRIPTION
I think this is a fix for older browsers where image widths aren't always respected without a `flex` rule.

Fixes #20 