### PR TITLE
chore: improved layout for profile info

### DIFF
--- a/src/modules/contribution/ContributionInfo.vue
+++ b/src/modules/contribution/ContributionInfo.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex justify-between pt-3 w-76">
-    <div>
+  <div class="flex pt-3 w-76">
+    <div class="flex-1">
       <div class="title uppercase">{{ t('common.joined') }}</div>
 
       <div class="content">
@@ -12,7 +12,7 @@
 
     <div class="w-px bg-primary-20" />
 
-    <div>
+    <div class="flex-1 pl-4">
       <div class="title uppercase">{{ t('common.contributing') }}</div>
 
       <div class="content">


### PR DESCRIPTION
Just a quick one to make the profile info look more like the design

Before: 
![image](https://user-images.githubusercontent.com/2084823/140162560-59f451cc-57be-4371-867e-fa7db34c4cb7.png)

After:
![image](https://user-images.githubusercontent.com/2084823/140162621-9a2cac39-329f-4655-b31a-41a580e1c384.png)

