### PR TITLE
feat: support locales with variants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 VITE_API_BASE_URL=/api/1.0/
 VITE_APP_BASE_URL=http://localhost:3000
-VITE_LOCALE=en
 VITE_CURRENCY=EUR
 VITE_NEWSROOM_NAME=Deine Lokalreporter
 VITE_NEWSROOM_LINK=https://example.com

--- a/locales/de.json
+++ b/locales/de.json
@@ -104,6 +104,7 @@
     "continue": "Weiter",
     "welcome": "Willkommen {firstname} {lastname}!"
   },
+  "locale": "de",
   "login": {
     "backTo": "Zurück zu {newsroomName}",
     "forgotPassword": "Passwort vergessen?",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -104,6 +104,7 @@
     "continue": "Weiter",
     "welcome": "Willkommen {firstname}!"
   },
+  "locale": "de",
   "login": {
     "backTo": "Zurück zu {newsroomName}",
     "forgotPassword": "Passwort vergessen?",

--- a/locales/en.json
+++ b/locales/en.json
@@ -104,6 +104,7 @@
     "continue": "All good! Continue",
     "welcome": "Welcome {firstName}!"
   },
+  "locale": "en",
   "login": {
     "backTo": "Back to {newsroomName}",
     "forgotPassword": "Forgot your password?",

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,9 +1,8 @@
 import { createI18n } from 'vue-i18n';
 import messages from '../locales/_current.json';
 
-const locale = import.meta.env.VITE_LOCALE as string;
-
 // We don't allow changing locales for now so fine to hardcode
+const locale = messages.locale;
 
 const numberFormats = {
   [locale]: {


### PR DESCRIPTION
Add support for locales with variants, e.g. in our case we have `de` and it's variant `de@informal`.