### PR TITLE
A few quick fixes from QA

### DIFF
--- a/src/modules/auth/join/components/AccountSection.vue
+++ b/src/modules/auth/join/components/AccountSection.vue
@@ -4,9 +4,11 @@
 
     <p class="mb-3 text-sm">
       {{ t('join.memberAlready') }}
-      <router-link to="/login" class="text-link hover:text-primary underline">{{
-        t('join.login')
-      }}</router-link>
+      <router-link
+        to="/auth/login"
+        class="text-link hover:text-primary underline"
+        >{{ t('join.login') }}</router-link
+      >
     </p>
 
     <div class="mb-5">

--- a/src/modules/auth/join/pages/DuplicateEmailPage.vue
+++ b/src/modules/auth/join/pages/DuplicateEmailPage.vue
@@ -8,7 +8,7 @@
       </template>
 
       <template #footer>
-        <AppButton to="/login" class="mb-2">
+        <AppButton to="/auth/login" class="mb-2">
           {{ t('join.login') }}
         </AppButton>
 

--- a/src/modules/contribution/ContributionPage.vue
+++ b/src/modules/contribution/ContributionPage.vue
@@ -75,7 +75,7 @@
 
         <CancelContribution
           class="mb-9 md:mb-0"
-          :cancellation-date="currentContribution.cancellationDate"
+          :expiry-date="currentContribution.membershipExpiryDate"
         />
       </template>
     </div>

--- a/src/modules/contribution/ContributionPage.vue
+++ b/src/modules/contribution/ContributionPage.vue
@@ -129,7 +129,9 @@ const {
   cantUpdatePaymentSource,
 } = useContribution();
 
-const period = computed(() => (isMonthly ? 'month' : 'year'));
+const period = computed(() =>
+  t(isMonthly.value ? 'common.month' : 'common.year')
+);
 
 onBeforeMount(() => {
   // - TODO: Why component isn't destroyed on route change?

--- a/src/modules/contribution/components/CancelContribution.vue
+++ b/src/modules/contribution/components/CancelContribution.vue
@@ -25,15 +25,15 @@ import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
 
 const props = defineProps({
-  cancellationDate: {
+  expiryDate: {
     type: String as () => null | string,
     default: '',
   },
 });
 
 const formattedDate = computed(() => {
-  if (!props.cancellationDate) return {};
-  const parsedDate = parseISO(props.cancellationDate);
+  if (!props.expiryDate) return {};
+  const parsedDate = parseISO(props.expiryDate);
   return {
     day: formatLocale(parsedDate, 'do'),
     month: formatLocale(parsedDate, 'LLLL'),


### PR DESCRIPTION
- Fix login links (should be `/auth/login`)
- Cancel contribution should show membership expiry date
- Show correct period in contribution box (and add i18n)