### PR TITLE
Add loading pages

### DIFF
--- a/src/layouts/LoadingLayout.vue
+++ b/src/layouts/LoadingLayout.vue
@@ -1,0 +1,33 @@
+<template>
+  <main class="auth min-h-screen bg-fixed bg-cover bg-center py-4">
+    <AuthBox class="text-center">
+      <img
+        class="w-28 inline-block mb-5"
+        src="../assets/images/logo.png"
+        :alt="newsroomName"
+      />
+      <h1 class="text-2.5xl mb-5">Loading...</h1>
+
+      <font-awesome-icon
+        :style="{ fontSize: '60px' }"
+        :icon="['fas', 'circle-notch']"
+        spin
+      />
+
+      <router-view />
+    </AuthBox>
+  </main>
+</template>
+
+<script lang="ts" setup>
+import AuthBox from '../modules/auth/AuthBox.vue';
+import AuthLayout from './AuthLayout.vue';
+
+const newsroomName = import.meta.env.VITE_NEWSROOM_NAME;
+</script>
+
+<style scoped>
+.auth {
+  background-image: url('../assets/images/auth-bg.jpg');
+}
+</style>

--- a/src/layouts/SplashLayout.vue
+++ b/src/layouts/SplashLayout.vue
@@ -1,5 +1,0 @@
-<template>
-  <main class="min-h-screen bg-grey-light py-4 md:py-8">
-    <router-view />
-  </main>
-</template>

--- a/src/modules/auth/join/join.route.ts
+++ b/src/modules/auth/join/join.route.ts
@@ -1,7 +1,5 @@
 import { RouteRecordRaw } from 'vue-router';
 import i18n from '../../../i18n';
-import { updateCurrentUser } from '../../../store';
-import { completeSignUp, confirmEmail } from '../../../utils/api/signup';
 
 const { t } = i18n.global;
 
@@ -26,24 +24,13 @@ export const joinRoute: Array<RouteRecordRaw> = [
     },
   },
   {
-    // this page is never shown, `beforeEnter` redirects
-    // the user to appropriate page
     path: '/join/complete',
     name: 'complete join',
     component: () => import('./pages/CompletePage.vue'),
     meta: {
+      layout: 'Loading',
       pageTitle: t('pageTitle.join'),
       noAuth: true,
-    },
-    beforeEnter(to, from, next) {
-      const redirectFlowId = to.query.redirect_flow_id;
-      completeSignUp(redirectFlowId as string)
-        .then(() => {
-          next('/join/confirm-email');
-        })
-        .catch(() => {
-          next('/join/failed');
-        });
     },
   },
   {
@@ -51,7 +38,7 @@ export const joinRoute: Array<RouteRecordRaw> = [
     name: 'confirm email',
     component: () => import('./pages/ConfirmEmailPage.vue'),
     meta: {
-      layout: 'Splash',
+      layout: 'Auth',
       noAuth: true,
       pageTitle: t('pageTitle.confirmEmail'),
     },
@@ -59,22 +46,11 @@ export const joinRoute: Array<RouteRecordRaw> = [
   {
     path: '/join/confirm-email/:id',
     name: 'confirm email id',
-    component: () => import('./pages/ConfirmEmailPage.vue'),
+    component: () => import('./pages/ConfirmEmailLoadingPage.vue'),
     meta: {
+      layout: 'Loading',
       noAuth: true,
       pageTitle: t('pageTitle.confirmEmail'),
-    },
-    beforeEnter(to, from, next) {
-      confirmEmail(to.params.id)
-        .then(updateCurrentUser)
-        .then(() => next('/join/setup'))
-        .catch((error) => {
-          if (error.response?.data?.code === 'duplicate-email') {
-            next('/join/duplicate-email');
-          } else {
-            next('/join/failed');
-          }
-        });
     },
   },
   {
@@ -82,7 +58,7 @@ export const joinRoute: Array<RouteRecordRaw> = [
     name: 'failed',
     component: () => import('./pages/FailedPage.vue'),
     meta: {
-      layout: 'Splash',
+      layout: 'Auth',
       noAuth: true,
       pageTitle: t('pageTitle.failed'),
     },
@@ -92,7 +68,7 @@ export const joinRoute: Array<RouteRecordRaw> = [
     name: 'duplicate email',
     component: () => import('./pages/DuplicateEmailPage.vue'),
     meta: {
-      layout: 'Splash',
+      layout: 'Auth',
       noAuth: true,
       pageTitle: t('pageTitle.duplicateEmail'),
     },

--- a/src/modules/auth/join/pages/CompletePage.vue
+++ b/src/modules/auth/join/pages/CompletePage.vue
@@ -1,1 +1,20 @@
-<template>Completing signup</template>
+<template><div /></template>
+
+<script lang="ts" setup>
+import { onBeforeMount } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { completeSignUp } from '../../../../utils/api/signup';
+
+const route = useRoute();
+const router = useRouter();
+
+onBeforeMount(() => {
+  completeSignUp(route.query.redirect_flow_id as string)
+    .then(() => {
+      router.replace('/join/confirm-email');
+    })
+    .catch(() => {
+      router.replace('/join/failed');
+    });
+});
+</script>

--- a/src/modules/auth/join/pages/ConfirmEmailLoadingPage.vue
+++ b/src/modules/auth/join/pages/ConfirmEmailLoadingPage.vue
@@ -1,0 +1,24 @@
+<template><div /></template>
+
+<script lang="ts" setup>
+import { onBeforeMount } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { updateCurrentUser } from '../../../../store';
+import { confirmEmail } from '../../../../utils/api/signup';
+
+const route = useRoute();
+const router = useRouter();
+
+onBeforeMount(() => {
+  confirmEmail(route.params.id)
+    .then(updateCurrentUser)
+    .then(() => router.replace('/join/setup'))
+    .catch((error) => {
+      if (error.response?.data?.code === 'duplicate-email') {
+        router.replace('/join/duplicate-email');
+      } else {
+        router.replace('/join/failed');
+      }
+    });
+});
+</script>

--- a/src/modules/contribution/CompleteFlow.vue
+++ b/src/modules/contribution/CompleteFlow.vue
@@ -1,6 +1,0 @@
-<template>
-  <!-- this page is never shown, `beforeEnter`
-       redirects the user to appropriate page
-  -->
-  Complete Contribution
-</template>

--- a/src/modules/contribution/contribution.route.ts
+++ b/src/modules/contribution/contribution.route.ts
@@ -1,9 +1,5 @@
 import { RouteRecordRaw } from 'vue-router';
 import i18n from '../../i18n';
-import {
-  completeStartContribution,
-  completeUpdatePaymentSource,
-} from '../../utils/api/member';
 
 const { t } = i18n.global;
 
@@ -15,42 +11,23 @@ export const contributionRoute: Array<RouteRecordRaw> = [
     meta: {
       pageTitle: t('menu.contribution'),
     },
-    // these pages are never shown, `beforeEnter` redirects
-    // the user to appropriate page.
-    // there is now `<router-view>` in contribution page
-    // - TODO: currently these pages are shown blank while makning requests
-    // maybe adding a loading indicator?
     children: [
       {
         path: 'complete',
         name: 'complete contribution',
-        component: () => import('./CompleteFlow.vue'),
-        beforeEnter(to, from, next) {
-          const redirectFlowId = to.query.redirect_flow_id;
-          completeStartContribution(redirectFlowId as string)
-            .then(() => {
-              next({
-                path: '/profile/contribution',
-                query: { startedContribution: null },
-              });
-            })
-            .catch((err) => err);
+        component: () => import('./pages/ContributionCompletePage.vue'),
+        meta: {
+          pageTitle: t('menu.contribution'),
+          layout: 'Loading',
         },
       },
       {
         path: 'payment-source/complete',
         name: 'complete payment source',
-        component: () => import('./CompleteFlow.vue'),
-        beforeEnter(to, from, next) {
-          const redirectFlowId = to.query.redirect_flow_id;
-          completeUpdatePaymentSource(redirectFlowId as string)
-            .then(() => {
-              next({
-                path: '/profile/contribution',
-                query: { updatedPaymentSource: null },
-              });
-            })
-            .catch((err) => err);
+        component: () => import('./pages/PaymentSourceCompletePage.vue'),
+        meta: {
+          pageTitle: t('menu.contribution'),
+          layout: 'Loading',
         },
       },
     ],

--- a/src/modules/contribution/contribution.route.ts
+++ b/src/modules/contribution/contribution.route.ts
@@ -11,26 +11,24 @@ export const contributionRoute: Array<RouteRecordRaw> = [
     meta: {
       pageTitle: t('menu.contribution'),
     },
-    children: [
-      {
-        path: 'complete',
-        name: 'complete contribution',
-        component: () => import('./pages/ContributionCompletePage.vue'),
-        meta: {
-          pageTitle: t('menu.contribution'),
-          layout: 'Loading',
-        },
-      },
-      {
-        path: 'payment-source/complete',
-        name: 'complete payment source',
-        component: () => import('./pages/PaymentSourceCompletePage.vue'),
-        meta: {
-          pageTitle: t('menu.contribution'),
-          layout: 'Loading',
-        },
-      },
-    ],
+  },
+  {
+    path: '/profile/contribution/complete',
+    name: 'complete contribution',
+    component: () => import('./pages/ContributionCompletePage.vue'),
+    meta: {
+      pageTitle: t('menu.contribution'),
+      layout: 'Loading',
+    },
+  },
+  {
+    path: '/profile/contribution/payment-source/complete',
+    name: 'complete payment source',
+    component: () => import('./pages/PaymentSourceCompletePage.vue'),
+    meta: {
+      pageTitle: t('menu.contribution'),
+      layout: 'Loading',
+    },
   },
   {
     path: '/profile/contribution/cancel',

--- a/src/modules/contribution/pages/ContributionCompletePage.vue
+++ b/src/modules/contribution/pages/ContributionCompletePage.vue
@@ -1,0 +1,21 @@
+<template><div /></template>
+
+<script lang="ts" setup>
+import { onBeforeMount } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { completeStartContribution } from '../../../utils/api/member';
+
+const route = useRoute();
+const router = useRouter();
+
+onBeforeMount(() => {
+  completeStartContribution(route.query.redirect_flow_id as string)
+    .then(() => {
+      router.replace({
+        path: '/profile/contribution',
+        query: { startedContribution: null },
+      });
+    })
+    .catch((err) => err);
+});
+</script>

--- a/src/modules/contribution/pages/PaymentSourceCompletePage.vue
+++ b/src/modules/contribution/pages/PaymentSourceCompletePage.vue
@@ -1,0 +1,21 @@
+<template><div /></template>
+
+<script lang="ts" setup>
+import { onBeforeMount } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { completeUpdatePaymentSource } from '../../../utils/api/member';
+
+const route = useRoute();
+const router = useRouter();
+
+onBeforeMount(() => {
+  completeUpdatePaymentSource(route.query.redirect_flow_id as string)
+    .then(() => {
+      router.replace({
+        path: '/profile/contribution',
+        query: { updatedPaymentSource: null },
+      });
+    })
+    .catch((err) => err);
+});
+</script>

--- a/src/router/router.interface.ts
+++ b/src/router/router.interface.ts
@@ -4,7 +4,7 @@ import { PermissionType } from '../utils/api/api.interface';
 declare module 'vue-router' {
   interface RouteMeta {
     pageTitle: string;
-    layout?: string;
+    layout?: 'Auth' | 'Dashboard' | 'Loading';
     noAuth?: boolean;
     role?: PermissionType;
   }


### PR DESCRIPTION
### Background image for error pages

A small change to make the join form error pages slightly more in keeping with the general design

Before:
![image](https://user-images.githubusercontent.com/2084823/151183915-090cc3a2-3c06-49fa-9ea3-6a3fc999f7c4.png)

After:
![image](https://user-images.githubusercontent.com/2084823/151183816-6dcc89fa-9dbb-45ea-80ca-2f909ff06cf3.png)

### Interstitial loading pages

When the user comes back from GoCardless they are currently presented with a blank page which hangs until the API request has completed. It's not usually for long (~0.5 secs) but could be longer on e.g. a slow connection and in general feels like something is broken, so this is a proposal to add a quick interstitial page the user sees while the request is completing

Before:
Blank page while API call completed

After:
![image](https://user-images.githubusercontent.com/2084823/151184262-babe0254-5db7-424a-bed1-5eb03c541139.png)
