### PR TITLE
Proposal: run Github Action job(s) on pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,12 @@
 name: Deploy
 
 on:
+  # a push to these branches will trigger the workflow
   push:
-    branches:
-      - main
+    branches: [main]
+  # a pull request targetting main will trigger the workflow
+  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       stage:


### PR DESCRIPTION
🚨 **Danger zone** 🚨

Currently, any PR targeting `main` would deploy to `dev.` – this is probably not what we want, but this is how we'd do it.

Not sure how we'd route things on the server so that _each_ PR gets its own subdomain or subdir and can thus be tested.

If that's desirable at all?