### PR TITLE
WIP: payments history table

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -87,6 +87,10 @@
     "hasPendingPayment": "Ihre Zahlung wird gerade verarbeitet.",
     "manualPayment": "Sie leisten Ihren Beitrag aktuell manuell via Banküberweisung. Richten Sie hier jetzt eine automatische Abbuchung via Lastschrift ein. Dann wird es für Sie leichter, Ihre Beiträge zu verwalten. Und wir bekommen einen besseren Überblick, auf welche Beiträge wir uns monatlich verlassen können.",
     "nextAmountChanging": "Ab dem {renewalDate} ist Ihr Beitrag {nextAmount}.",
+    "paymentHistory": {
+      "amount": "Betrag",
+      "date": "Datum"
+    },
     "paymentSourceUpdateError": "Sie können Ihre Bankverbindung aktuell nicht ändern, weil eine Zahlung kurz bevorsteht.",
     "prorateDecreaseMessage": "Ihr Beitrag bleibt noch für {monthsLeft} {months} gleich. Der neue Beitrag wird am {renewalDate} zum ersten Mal eingezogen.",
     "prorateIncreaseMessage": "Ihre Mitgliedschaft läuft noch {monthsLeft} {months} unter diesem Beitrag. Sie können eine Einmalzahlung in Höhe von {oneOffPayment} leisten um Ihre Mitgliedschaft sofort zu erneuern und den Beitrag zu erhöhen.",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -87,6 +87,10 @@
     "hasPendingPayment": "Deine Zahlung wird gerade verarbeitet.",
     "manualPayment": "Du leistest deinen Beitrag aktuell manuell via Banküberweisung. Richte hier jetzt eine automatische Abbuchung via Lastschrift ein. Dann wird es für dich leichter, deine Beiträge zu verwalten. Und wir bekommen einen besseren Überblick, auf welche Beiträge wir uns monatlich verlassen können.",
     "nextAmountChanging": "Ab dem {renewalDate} ist dein Beitrag {nextAmount}.",
+    "paymentHistory": {
+      "amount": "Betrag",
+      "date": "Datum"
+    },
     "paymentSourceUpdateError": "Du kannst deine Bankverbindung aktuell nicht ändern, weil eine Zahlung kurz bevorsteht.",
     "prorateDecreaseMessage": "Dein Beitrag bleibt noch für {monthsLeft} {months} gleich. Der neue Beitrag wird am {renewalDate} zum ersten Mal eingezogen.",
     "prorateIncreaseMessage": "Deine Mitgliedschaft läuft noch {monthsLeft} {months} unter diesem Beitrag. Du kannst eine Einmalzahlung in Höhe von {oneOffPayment} leisten um deine Mitgliedschaft sofort zu erneuern und den Beitrag zu erhöhen.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -108,7 +108,8 @@
     "nextAmountChanging": "Your contribution will change to {nextAmount} on {renewalDate}.",
     "paymentHistory": {
       "amount": "Amount",
-      "date": "Date"
+      "date": "Date",
+      "title": "Payment history"
     },
     "paymentSourceUpdateError": "You can't update your bank account at the moment as you have a payment pending",
     "prorateDecreaseMessage": "You have {monthsLeft} {months} left on your current contribution, your new contribution will start on {renewalDate}.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -106,6 +106,10 @@
     "hasPendingPayment": "Your payment is currently being processed.",
     "manualPayment": "You are paying manually through bank transfer right now. To make it easier for you to manage your contribution and easier for us to know on how much money from our members we can rely on month on month, please update to paying automatically via direct debit.",
     "nextAmountChanging": "Your contribution will change to {nextAmount} on {renewalDate}.",
+    "paymentHistory": {
+      "amount": "Amount",
+      "date": "Date"
+    },
     "paymentSourceUpdateError": "You can't update your bank account at the moment as you have a payment pending",
     "prorateDecreaseMessage": "You have {monthsLeft} {months} left on your current contribution, your new contribution will start on {renewalDate}.",
     "prorateIncreaseMessage": "You have {monthsLeft} {months} left on your current contribution. You can make a one-off payment of {oneOffPayment} to start your new contribution immediately.",

--- a/src/components/AppPagination.vue
+++ b/src/components/AppPagination.vue
@@ -2,8 +2,10 @@
   <ul class="flex items-center -mx-2">
     <li>
       <button
-        class="p-2"
-        :class="isFirst && 'opacity-25'"
+        :class="
+          isFirst &&
+          'opacity-25 p-2 bg-primary hover:bg-white hover:font-bold hover:border-link'
+        "
         :disabled="isFirst"
         @click="emit('update:modelValue', modelValue - 1)"
       >
@@ -16,7 +18,14 @@
         <button
           :class="page === modelValue && 'text-link bg-white'"
           :disabled="page === modelValue"
-          class="p-2 leading-none border border-primary rounded mx-1"
+          class="
+            leading-none
+            border border-primary
+            rounded
+            mx-1
+            p-2
+            hover:font-bold hover:border-link
+          "
           @click="emit('update:modelValue', page)"
         >
           {{ page + 1 }}
@@ -25,8 +34,10 @@
     </template>
     <li>
       <button
-        class="p-2"
-        :class="isLast && 'opacity-25'"
+        :class="
+          isLast &&
+          'opacity-25 p-2 bg-primary hover:bg-white hover:font-bold hover:border-link'
+        "
         :disabled="isLast"
         @click="emit('update:modelValue', modelValue + 1)"
       >

--- a/src/components/table/AppTable.vue
+++ b/src/components/table/AppTable.vue
@@ -7,7 +7,7 @@
           :key="i"
           class="p-2 relative"
           :class="{ 'cursor-pointer': header.sortable }"
-          align="left"
+          :align="header.align || 'left'"
           :style="{ width: header.width }"
           @click="sortBy(header)"
         >

--- a/src/components/table/AppTable.vue
+++ b/src/components/table/AppTable.vue
@@ -1,6 +1,6 @@
 <template>
   <table class="font-semibold">
-    <thead class="text-sm border-b border-primary-20">
+    <thead v-if="!hideHeaders" class="text-sm border-b border-primary-20">
       <tr>
         <th
           v-for="(header, i) in headers"
@@ -56,6 +56,7 @@ const props = defineProps<{
   sort: Sort;
   headers: Header[];
   items: any[]; // TODO: improve typing
+  hideHeaders: boolean;
 }>();
 
 const emit = defineEmits(['update:sort']);

--- a/src/components/table/AppTable.vue
+++ b/src/components/table/AppTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <table class="font-semibold">
+  <table class="">
     <thead v-if="!hideHeaders" class="text-sm border-b border-primary-20">
       <tr>
         <th

--- a/src/modules/contribution/ContributionPage.vue
+++ b/src/modules/contribution/ContributionPage.vue
@@ -88,7 +88,7 @@
         />
       </template>
     </div>
-    <PaymentsHistory id="me" />
+    <PaymentsHistory id="me" class="lg:ml-10" />
   </div>
 
   <div class="text-center md:hidden">

--- a/src/modules/contribution/ContributionPage.vue
+++ b/src/modules/contribution/ContributionPage.vue
@@ -88,25 +88,7 @@
         />
       </template>
     </div>
-    <div>
-      <SectionTitle class="mb-2">Payment history </SectionTitle>
-      <AppTable
-        :sort="{ by: 'chargeDate', type: SortType.Desc }"
-        :headers="[
-          { value: 'chargeDate', text: 'date' },
-          { value: 'amount', text: 'amt', align: 'right' },
-        ]"
-        :items="[
-          { chargeDate: 'Feb 2022', amount: 10 },
-          { chargeDate: 'Jan 2022', amount: 11 },
-        ]"
-        class="w-full"
-      >
-        <template #amount="{ value }"
-          ><b>{{ n(value, 'currency') }}</b></template
-        >
-      </AppTable>
-    </div>
+    <PaymentsHistory id="me" />
   </div>
 
   <div class="text-center md:hidden">
@@ -134,11 +116,9 @@ import AppButton from '../../components/forms/AppButton.vue';
 import ProrateContribution from './components/ProrateContribution.vue';
 import AppAlert from '../../components/AppAlert.vue';
 import MessageBox from '../../components/MessageBox.vue';
+import PaymentsHistory from './components/PaymentsHistory.vue';
 
-import AppTable from '../../components/table/AppTable.vue';
-import { SortType } from '../../components/table/table.interface';
-
-const { t, n } = useI18n();
+const { t } = useI18n();
 
 const route = useRoute();
 const updatedPaymentSource = route.query.updatedPaymentSource !== undefined;

--- a/src/modules/contribution/ContributionPage.vue
+++ b/src/modules/contribution/ContributionPage.vue
@@ -3,7 +3,7 @@
     <PageTitle :title="t('menu.contribution')" />
   </div>
 
-  <div v-if="!isIniting" class="grid lg:grid-cols-2 xl:grid-cols-3">
+  <div v-if="!isIniting" class="grid lg:grid-cols-2 xl:grid-cols-3 gap-8">
     <div>
       <AppAlert v-if="updatedPaymentSource" class="mb-8">{{
         t('contribution.updatedPaymentSource')
@@ -88,6 +88,25 @@
         />
       </template>
     </div>
+    <div>
+      <SectionTitle class="mb-2">Payment history </SectionTitle>
+      <AppTable
+        :sort="{ by: 'chargeDate', type: SortType.Desc }"
+        :headers="[
+          { value: 'chargeDate', text: 'date' },
+          { value: 'amount', text: 'amt', align: 'right' },
+        ]"
+        :items="[
+          { chargeDate: 'Feb 2022', amount: 10 },
+          { chargeDate: 'Jan 2022', amount: 11 },
+        ]"
+        class="w-full"
+      >
+        <template #amount="{ value }"
+          ><b>{{ n(value, 'currency') }}</b></template
+        >
+      </AppTable>
+    </div>
   </div>
 
   <div class="text-center md:hidden">
@@ -116,7 +135,10 @@ import ProrateContribution from './components/ProrateContribution.vue';
 import AppAlert from '../../components/AppAlert.vue';
 import MessageBox from '../../components/MessageBox.vue';
 
-const { t } = useI18n();
+import AppTable from '../../components/table/AppTable.vue';
+import { SortType } from '../../components/table/table.interface';
+
+const { t, n } = useI18n();
 
 const route = useRoute();
 const updatedPaymentSource = route.query.updatedPaymentSource !== undefined;

--- a/src/modules/contribution/components/PaymentsHistory.vue
+++ b/src/modules/contribution/components/PaymentsHistory.vue
@@ -14,11 +14,13 @@
         ><b>{{ n(value, 'currency') }}</b></template
       >
     </AppTable>
-    <AppPagination
-      v-model="currentPage"
-      :total-pages="totalPages"
-      class="mt-6"
-    />
+    <div class="flex w-full justify-center">
+      <AppPagination
+        v-model="currentPage"
+        :total-pages="totalPages"
+        class="mt-6"
+      />
+    </div>
   </div>
 </template>
 

--- a/src/modules/contribution/components/PaymentsHistory.vue
+++ b/src/modules/contribution/components/PaymentsHistory.vue
@@ -36,7 +36,7 @@ import { Paginated } from '../../../utils/api/api.interface';
 import { GetPaymentData } from '../../../utils/api/api.interface';
 import { Header, SortType } from '../../../components/table/table.interface';
 
-const { n } = useI18n();
+const { t, n } = useI18n();
 
 const props = defineProps<{
   id: string;
@@ -55,8 +55,12 @@ const totalPages = computed(() =>
 );
 
 const headers: Header[] = [
-  { value: 'chargeDate', text: 'Date' },
-  { value: 'amount', text: 'Amount', align: 'right' },
+  { value: 'chargeDate', text: t('contribution.paymentHistory.date') },
+  {
+    value: 'amount',
+    text: t('contribution.paymentHistory.amount'),
+    align: 'right',
+  },
 ];
 
 watchEffect(async () => {

--- a/src/modules/contribution/components/PaymentsHistory.vue
+++ b/src/modules/contribution/components/PaymentsHistory.vue
@@ -5,6 +5,7 @@
       :sort="{ by: 'chargeDate', type: SortType.Desc }"
       :headers="headers"
       :items="paymentsHistoryTable.items"
+      :hide-headers="true"
       class="w-full"
     >
       <template #chargeDate="{ value }">

--- a/src/modules/contribution/components/PaymentsHistory.vue
+++ b/src/modules/contribution/components/PaymentsHistory.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <SectionTitle class="mb-2">Payment history </SectionTitle>
+    <SectionTitle class="mb-2">{{
+      t('contribution.paymentHistory.title')
+    }}</SectionTitle>
     <AppTable
       :sort="{ by: 'chargeDate', type: SortType.Desc }"
       :headers="headers"

--- a/src/modules/contribution/components/PaymentsHistory.vue
+++ b/src/modules/contribution/components/PaymentsHistory.vue
@@ -51,7 +51,7 @@ const paymentsHistoryTable = ref<Paginated<GetPaymentData>>({
   count: 0,
   total: 0,
 });
-const pageSize = 3;
+const pageSize = 10;
 const currentPage = ref(0);
 const totalPages = computed(() =>
   Math.ceil(paymentsHistoryTable.value.total / pageSize)

--- a/src/modules/contribution/components/PaymentsHistory.vue
+++ b/src/modules/contribution/components/PaymentsHistory.vue
@@ -53,7 +53,7 @@ const paymentsHistoryTable = ref<Paginated<GetPaymentData>>({
   count: 0,
   total: 0,
 });
-const pageSize = 10;
+const pageSize = 12;
 const currentPage = ref(0);
 const totalPages = computed(() =>
   Math.ceil(paymentsHistoryTable.value.total / pageSize)


### PR DESCRIPTION
This PR implements a new component allowing a member to see the history of their financial contributions when visiting `/profile/contribution`.

Screenshots and original designs are below.

Please note that a couple of things (pagination buttons, table rows) look ever so slightly different from the designs – that is, pardon the pun, _by design._ I chose to favour consistency and our current implementation over including new `if/else` statements on otherwise quite standardised components.

Ana, Ricardo, I'll trust you'll flag what matters to you too 🙂

**One item of note** is the omission of the "select year" button, which requires a new round trip to the API while we've gone to some lengths to cut the size of the queries with pagination, as well as some other on-the-fly minor computations. For the sake of moving the larger piece of work across the line, I've left this out and would prefer it landed in a backlog of small tasks I can pick up when there's a bit more time, if that's okay with you.

---

### Original design
![image](https://user-images.githubusercontent.com/5701152/156182290-6a5a6f77-7c6a-41d1-a8e9-4bdb26ad16c7.png)
