### PR TITLE
feat: add impressum link from generalContent

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -97,6 +97,7 @@
     "contactUs": "Kontaktieren Sie uns unter",
     "contacts": "Kontakte",
     "handbookResources": "Handbuch & Ressourcen",
+    "impressum": "Impressum",
     "joinCommunity": "Mitglied werden",
     "poweredBy": "Wir stärken unabhängige Lokalredaktionen.",
     "privacyPolicy": "Datenschutzerklärung",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -97,6 +97,7 @@
     "contactUs": "Kontaktiere uns unter",
     "contacts": "Kontakte",
     "handbookResources": "Handbuch & Ressourcen",
+    "impressum": "Impressum",
     "joinCommunity": "Mitglied werden",
     "poweredBy": "Wir stärken unabhängige Lokalredaktionen.",
     "privacyPolicy": "Datenschutzerklärung",

--- a/locales/en.json
+++ b/locales/en.json
@@ -107,6 +107,7 @@
     "contactUs": "Contact us at",
     "contacts": "Contacts",
     "handbookResources": "Handbook & Resources",
+    "impressum": "Impressum",
     "joinCommunity": "Join the Community",
     "poweredBy": "powering independent local newsrooms",
     "privacyPolicy": "Privacy Policy",

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -35,6 +35,11 @@
           <li v-if="generalContent.termsLink">
             <a :href="generalContent.termsLink">{{ t('footer.terms') }}</a>
           </li>
+          <li v-if="generalContent.impressumLink">
+            <a :href="generalContent.impressumLink">{{
+              t('footer.impressum')
+            }}</a>
+          </li>
         </ul>
       </div>
       <div class="mr-8 mb-6">

--- a/src/utils/api/api.interface.ts
+++ b/src/utils/api/api.interface.ts
@@ -128,7 +128,8 @@ export interface GeneralContent {
   siteUrl: string;
   supportEmail: string;
   privacyLink: string;
-  termsLink: string;
+  termsLink?: string;
+  impressumLink?: string;
   currencyCode: string;
   footerLinks: { text: string; url: string }[];
 }


### PR DESCRIPTION
For the email footer in https://github.com/beabee-communityrm/beabee/pull/123 the Impressum link needed to be in a specific place so I've pulled it out as separate from `generalContent.footerLinks` and into a specific optional `generalContent.impressumLink`