### PR TITLE
Chore/design tweaks

### DIFF
--- a/src/components/AppPagination.vue
+++ b/src/components/AppPagination.vue
@@ -2,10 +2,8 @@
   <ul class="flex items-center -mx-2">
     <li>
       <button
-        :class="
-          isFirst &&
-          'opacity-25 p-2 bg-primary hover:bg-white hover:font-bold hover:border-link'
-        "
+        class="p-2"
+        :class="isFirst && 'opacity-25 hover:font-bold hover:border-link'"
         :disabled="isFirst"
         @click="emit('update:modelValue', modelValue - 1)"
       >
@@ -16,7 +14,9 @@
       <li v-if="index > 0 && pages[index - 1] !== page - 1">&hellip;</li>
       <li>
         <button
-          :class="page === modelValue && 'text-link bg-white'"
+          :class="
+            page === modelValue && 'text-link bg-white font-bold border-link'
+          "
           :disabled="page === modelValue"
           class="
             leading-none
@@ -34,10 +34,8 @@
     </template>
     <li>
       <button
-        :class="
-          isLast &&
-          'opacity-25 p-2 bg-primary hover:bg-white hover:font-bold hover:border-link'
-        "
+        class="p-2"
+        :class="isLast && 'opacity-25 hover:font-bold hover:border-link'"
         :disabled="isLast"
         @click="emit('update:modelValue', modelValue + 1)"
       >

--- a/src/modules/contribution/components/PaymentsHistory.vue
+++ b/src/modules/contribution/components/PaymentsHistory.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="paymentsHistoryTable.total > 0">
     <SectionTitle class="mb-2">{{
       t('contribution.paymentHistory.title')
     }}</SectionTitle>

--- a/src/modules/home/HomePage.vue
+++ b/src/modules/home/HomePage.vue
@@ -29,42 +29,40 @@
     <QuickActions />
   </section>
 
-  <div class="lg:flex justify-between">
-    <section v-if="callouts.length" class="mb-6 lg:mr-6">
-      <SectionTitle class="mb-6 md:hidden">{{
-        t('homePage.openCallouts')
-      }}</SectionTitle>
-      <AppHeading class="mb-2 hidden md:block">{{
-        t('homePage.openCallouts')
-      }}</AppHeading>
+  <section v-if="callouts.length" class="mb-6 lg:mr-6">
+    <SectionTitle class="mb-6 md:hidden">{{
+      t('homePage.openCallouts')
+    }}</SectionTitle>
+    <AppHeading class="mb-2 hidden md:block">{{
+      t('homePage.openCallouts')
+    }}</AppHeading>
 
-      <div class="flex mb-4">
-        <!-- just show the first callout for now (design decision) -->
-        <CalloutCard :callout="callouts[0]" />
-      </div>
+    <div class="flex mb-4">
+      <!-- just show the first callout for now (design decision) -->
+      <CalloutCard :callout="callouts[0]" />
+    </div>
 
-      <!--<AppButton to="/callouts" variant="primaryOutlined">{{
+    <!--<AppButton to="/callouts" variant="primaryOutlined">{{
         t('homePage.viewAllCallouts')
       }}</AppButton>-->
-    </section>
+  </section>
 
-    <section>
-      <SectionTitle class="mb-6 md:hidden">{{
-        t('homePage.yourProfile')
-      }}</SectionTitle>
-      <AppHeading class="mb-2 hidden md:block">{{
-        t('homePage.yourProfile')
-      }}</AppHeading>
+  <section>
+    <SectionTitle class="mb-6 md:hidden">{{
+      t('homePage.yourProfile')
+    }}</SectionTitle>
+    <AppHeading class="mb-2 hidden md:block">{{
+      t('homePage.yourProfile')
+    }}</AppHeading>
 
-      <div class="flex mb-4">
-        <ContributionInfo :member="user" />
-      </div>
+    <div class="flex mb-4">
+      <ContributionInfo :member="user" />
+    </div>
 
-      <AppButton to="/profile/contribution" variant="primaryOutlined">{{
-        t('homePage.manageContribution')
-      }}</AppButton>
-    </section>
-  </div>
+    <AppButton to="/profile/contribution" variant="primaryOutlined">{{
+      t('homePage.manageContribution')
+    }}</AppButton>
+  </section>
 
   <section class="hidden pt-20 mt-auto max-w-xs md:max-w-sm mx-auto">
     <ThanksNotice>{{ profileContent.footerMessage }}</ThanksNotice>

--- a/src/modules/home/components/ContributionInfo.vue
+++ b/src/modules/home/components/ContributionInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex pt-3 w-76">
+  <div class="flex pt-3 w-[17rem]">
     <div class="flex-1">
       <div class="title uppercase">{{ t('common.joined') }}</div>
 


### PR DESCRIPTION
A few tweaks to fix/change 

#### Hide empty payments history

![image](https://user-images.githubusercontent.com/2084823/160373944-ca1459a0-4251-42d2-8281-42e2d899aa95.png)

#### Fix pagination colours

![image](https://user-images.githubusercontent.com/2084823/160373282-0ca81e64-313e-423d-96e3-ddc25b7e9872.png)
![image](https://user-images.githubusercontent.com/2084823/160373225-9f3cc999-d2e4-482d-bfc4-adcfc4818b7f.png)

#### Fix profile info width

![image](https://user-images.githubusercontent.com/2084823/160373004-27c24e50-1c84-4ca4-a611-841241075994.png)
![image](https://user-images.githubusercontent.com/2084823/160373084-6192c117-04c1-4fb2-9773-81bb58225f2b.png)

#### Always put profile info below callouts as it gets lost on the right on big screens

![image](https://user-images.githubusercontent.com/2084823/160373633-780ddbfa-3f92-4986-a143-a0d73a247ba6.png)
![image](https://user-images.githubusercontent.com/2084823/160373597-75ed9835-bc55-4e4d-a869-2d2940d59b6c.png)
