### PR TITLE
Limited markdown functionality for i18n strings

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -65,11 +65,7 @@
   "contactOverview": {
     "about": "Über",
     "annotation": {
-      "copy": {
-        "begin": "Alle hier eingegebenen Information sind",
-        "bold": "nur für Administratoren sichtbar.",
-        "end": "Nutzer bekommen das nicht angezeigt."
-      }
+      "copy": "<p>Alle hier eingegebenen Information sind <strong>nur für Administratoren sichtbar</strong>.\nNutzer bekommen das nicht angezeigt.</p>\n"
     },
     "contribution": "Beitrag",
     "information": "Information",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -65,11 +65,7 @@
   "contactOverview": {
     "about": "Über",
     "annotation": {
-      "copy": {
-        "begin": "Alle hier eingegebenen Information sind",
-        "bold": "nur für Administratoren sichtbar.",
-        "end": "Nutzer bekommen das nicht angezeigt."
-      }
+      "copy": "<p>Alle hier eingegebenen Information sind <strong>nur für Administratoren sichtbar</strong>.\nNutzer bekommen das nicht angezeigt.</p>\n"
     },
     "contribution": "Beitrag",
     "information": "Information",

--- a/locales/en.json
+++ b/locales/en.json
@@ -68,11 +68,7 @@
   "contactOverview": {
     "about": "About",
     "annotation": {
-      "copy": {
-        "begin": "All information added in this section is",
-        "bold": "visible for admins only.",
-        "end": "Members will never see these in their profile or member area."
-      }
+      "copy": "<p>All information added in this section is <strong>visible for admins only</strong>. Members will never see these in their profile or member area.</p>\n"
     },
     "contribution": "Contribution",
     "information": "Information",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "googleapis": "^91.0.0",
         "husky": "^7.0.4",
         "lint-staged": "^11.1.2",
+        "markdown-it": "^12.3.2",
         "postcss": "^8.4.0",
         "prettier": "^2.4.1",
         "stylelint": "^13.13.0",
@@ -309,6 +310,7 @@
       "version": "7.15.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
       "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -481,6 +483,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
       "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
@@ -1395,28 +1398,6 @@
         "upath": "^2.0.1"
       }
     },
-    "node_modules/@volar/vue-code-gen/node_modules/@vue/compiler-core": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.22.tgz",
-      "integrity": "sha512-uAkovrVeTcjzpiM4ECmVaMrv/bjdgAaLzvjcGqQPBEyUrcqsCgccT9fHJ/+hWVGhyMahmBwLqcn4guULNx7sdw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.15.0",
-        "@vue/shared": "3.2.22",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@volar/vue-code-gen/node_modules/@vue/compiler-dom": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.22.tgz",
-      "integrity": "sha512-VZdsw/VuO1ODs8K7NQwnMQzKITDkIFlYYC03SVnunuf6eNRxBPEonSyqbWNoo6qNaHAEBTG6VVcZC5xC9bAx1g==",
-      "dev": true,
-      "dependencies": {
-        "@vue/compiler-core": "3.2.22",
-        "@vue/shared": "3.2.22"
-      }
-    },
     "node_modules/@volar/vue-code-gen/node_modules/@vue/shared": {
       "version": "3.2.22",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.22.tgz",
@@ -1444,101 +1425,50 @@
       "dev": true
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.6.tgz",
-      "integrity": "sha512-vbwnz7+OhtLO5p5i630fTuQCL+MlUpEMTKHuX+RfetQ+3pFCkItt2JUH+9yMaBG2Hkz6av+T9mwN/acvtIwpbw==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.31.tgz",
+      "integrity": "sha512-aKno00qoA4o+V/kR6i/pE+aP+esng5siNAVQ422TkBNM6qA4veXiZbSe8OTXHXquEi/f6Akc+nLfB4JGfe4/WQ==",
       "dependencies": {
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
-        "@vue/shared": "3.2.6",
+        "@babel/parser": "^7.16.4",
+        "@vue/shared": "3.2.31",
         "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.6.tgz",
-      "integrity": "sha512-+a/3oBAzFIXhHt8L5IHJOTP4a5egzvpXYyi13jR7CUYOR1S+Zzv7vBWKYBnKyJLwnrxTZnTQVjeHCgJq743XKg==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.31.tgz",
+      "integrity": "sha512-60zIlFfzIDf3u91cqfqy9KhCKIJgPeqxgveH2L+87RcGU/alT6BRrk5JtUso0OibH3O7NXuNOQ0cDc9beT0wrg==",
       "dependencies": {
-        "@vue/compiler-core": "3.2.6",
-        "@vue/shared": "3.2.6"
+        "@vue/compiler-core": "3.2.31",
+        "@vue/shared": "3.2.31"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.22.tgz",
-      "integrity": "sha512-tWRQ5ge1tsTDhUwHgueicKJ8rYm6WUVAPTaIpFW3GSwZKcOEJ2rXdfkHFShNVGupeRALz2ET2H84OL0GeRxY0A==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.31.tgz",
+      "integrity": "sha512-748adc9msSPGzXgibHiO6T7RWgfnDcVQD+VVwYgSsyyY8Ans64tALHZANrKtOzvkwznV/F4H7OAod/jIlp/dkQ==",
       "dependencies": {
-        "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.22",
-        "@vue/compiler-dom": "3.2.22",
-        "@vue/compiler-ssr": "3.2.22",
-        "@vue/ref-transform": "3.2.22",
-        "@vue/shared": "3.2.22",
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.31",
+        "@vue/compiler-dom": "3.2.31",
+        "@vue/compiler-ssr": "3.2.31",
+        "@vue/reactivity-transform": "3.2.31",
+        "@vue/shared": "3.2.31",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7",
         "postcss": "^8.1.10",
         "source-map": "^0.6.1"
       }
     },
-    "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-core": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.22.tgz",
-      "integrity": "sha512-uAkovrVeTcjzpiM4ECmVaMrv/bjdgAaLzvjcGqQPBEyUrcqsCgccT9fHJ/+hWVGhyMahmBwLqcn4guULNx7sdw==",
-      "dependencies": {
-        "@babel/parser": "^7.15.0",
-        "@vue/shared": "3.2.22",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-dom": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.22.tgz",
-      "integrity": "sha512-VZdsw/VuO1ODs8K7NQwnMQzKITDkIFlYYC03SVnunuf6eNRxBPEonSyqbWNoo6qNaHAEBTG6VVcZC5xC9bAx1g==",
-      "dependencies": {
-        "@vue/compiler-core": "3.2.22",
-        "@vue/shared": "3.2.22"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/@vue/shared": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.22.tgz",
-      "integrity": "sha512-qWVav014mpjEtbWbEgl0q9pEyrrIySKum8UVYjwhC6njrKzknLZPvfuYdQyVbApsqr94tf/3dP4pCuZmmjdCWQ=="
-    },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.22.tgz",
-      "integrity": "sha512-Cl6aoLJtXzzBkk1sKod8S0WBJLts3+ugVC91d22gGpbkw/64WnF12tOZi7Rg54PPLi1NovqyNWPsLH/SAFcu+w==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.31.tgz",
+      "integrity": "sha512-mjN0rqig+A8TVDnsGPYJM5dpbjlXeHUm2oZHZwGyMYiGT/F4fhJf/cXy8QpjnLQK4Y9Et4GWzHn9PS8AHUnSkw==",
       "dependencies": {
-        "@vue/compiler-dom": "3.2.22",
-        "@vue/shared": "3.2.22"
+        "@vue/compiler-dom": "3.2.31",
+        "@vue/shared": "3.2.31"
       }
-    },
-    "node_modules/@vue/compiler-ssr/node_modules/@vue/compiler-core": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.22.tgz",
-      "integrity": "sha512-uAkovrVeTcjzpiM4ECmVaMrv/bjdgAaLzvjcGqQPBEyUrcqsCgccT9fHJ/+hWVGhyMahmBwLqcn4guULNx7sdw==",
-      "dependencies": {
-        "@babel/parser": "^7.15.0",
-        "@vue/shared": "3.2.22",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@vue/compiler-ssr/node_modules/@vue/compiler-dom": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.22.tgz",
-      "integrity": "sha512-VZdsw/VuO1ODs8K7NQwnMQzKITDkIFlYYC03SVnunuf6eNRxBPEonSyqbWNoo6qNaHAEBTG6VVcZC5xC9bAx1g==",
-      "dependencies": {
-        "@vue/compiler-core": "3.2.22",
-        "@vue/shared": "3.2.22"
-      }
-    },
-    "node_modules/@vue/compiler-ssr/node_modules/@vue/shared": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.22.tgz",
-      "integrity": "sha512-qWVav014mpjEtbWbEgl0q9pEyrrIySKum8UVYjwhC6njrKzknLZPvfuYdQyVbApsqr94tf/3dP4pCuZmmjdCWQ=="
     },
     "node_modules/@vue/devtools-api": {
       "version": "6.0.0-beta.15",
@@ -1578,64 +1508,60 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.6.tgz",
-      "integrity": "sha512-8vIDD2wpCnYisNNZjmcIj+Rixn0uhZNY3G1vzlgdVdLygeRSuFjkmnZk6WwvGzUWpKfnG0e/NUySM3mVi59hAA==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.31.tgz",
+      "integrity": "sha512-HVr0l211gbhpEKYr2hYe7hRsV91uIVGFYNHj73njbARVGHQvIojkImKMaZNDdoDZOIkMsBc9a1sMqR+WZwfSCw==",
       "dependencies": {
-        "@vue/shared": "3.2.6"
+        "@vue/shared": "3.2.31"
       }
     },
-    "node_modules/@vue/ref-transform": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.22.tgz",
-      "integrity": "sha512-qalVWbq5xWWxLZ0L9OroBg/JZhzavQuCcDXblfErxyDEH6Xc5gIJ4feo1SVCICFzhAUgLgQTdSFLpgjBawbFpw==",
+    "node_modules/@vue/reactivity-transform": {
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.31.tgz",
+      "integrity": "sha512-uS4l4z/W7wXdI+Va5pgVxBJ345wyGFKvpPYtdSgvfJfX/x2Ymm6ophQlXXB6acqGHtXuBqNyyO3zVp9b1r0MOA==",
       "dependencies": {
-        "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.22",
-        "@vue/shared": "3.2.22",
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.31",
+        "@vue/shared": "3.2.31",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
       }
     },
-    "node_modules/@vue/ref-transform/node_modules/@vue/compiler-core": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.22.tgz",
-      "integrity": "sha512-uAkovrVeTcjzpiM4ECmVaMrv/bjdgAaLzvjcGqQPBEyUrcqsCgccT9fHJ/+hWVGhyMahmBwLqcn4guULNx7sdw==",
-      "dependencies": {
-        "@babel/parser": "^7.15.0",
-        "@vue/shared": "3.2.22",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@vue/ref-transform/node_modules/@vue/shared": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.22.tgz",
-      "integrity": "sha512-qWVav014mpjEtbWbEgl0q9pEyrrIySKum8UVYjwhC6njrKzknLZPvfuYdQyVbApsqr94tf/3dP4pCuZmmjdCWQ=="
-    },
     "node_modules/@vue/runtime-core": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.6.tgz",
-      "integrity": "sha512-3mqtgpj/YSGFxtvTufSERRApo92B16JNNxz9p+5eG6PPuqTmuRJz214MqhKBEgLEAIQ6R6YCbd83ZDtjQnyw2g==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.31.tgz",
+      "integrity": "sha512-Kcog5XmSY7VHFEMuk4+Gap8gUssYMZ2+w+cmGI6OpZWYOEIcbE0TPzzPHi+8XTzAgx1w/ZxDFcXhZeXN5eKWsA==",
       "dependencies": {
-        "@vue/reactivity": "3.2.6",
-        "@vue/shared": "3.2.6"
+        "@vue/reactivity": "3.2.31",
+        "@vue/shared": "3.2.31"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.6.tgz",
-      "integrity": "sha512-fq33urnP0BNCGm2O3KCzkJlKIHI80C94HJ4qDZbjsTtxyOn5IHqwKSqXVN3RQvO6epcQH+sWS+JNwcNDPzoasg==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.31.tgz",
+      "integrity": "sha512-N+o0sICVLScUjfLG7u9u5XCjvmsexAiPt17GNnaWHJUfsKed5e85/A3SWgKxzlxx2SW/Hw7RQxzxbXez9PtY3g==",
       "dependencies": {
-        "@vue/runtime-core": "3.2.6",
-        "@vue/shared": "3.2.6",
+        "@vue/runtime-core": "3.2.31",
+        "@vue/shared": "3.2.31",
         "csstype": "^2.6.8"
       }
     },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.31.tgz",
+      "integrity": "sha512-8CN3Zj2HyR2LQQBHZ61HexF5NReqngLT3oahyiVRfSSvak+oAvVmu8iNLSu6XR77Ili2AOpnAt1y8ywjjqtmkg==",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.2.31",
+        "@vue/shared": "3.2.31"
+      },
+      "peerDependencies": {
+        "vue": "3.2.31"
+      }
+    },
     "node_modules/@vue/shared": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.6.tgz",
-      "integrity": "sha512-uwX0Qs2e6kdF+WmxwuxJxOnKs/wEkMArtYpHSm7W+VY/23Tl8syMRyjnzEeXrNCAP0/8HZxEGkHJsjPEDNRuHw=="
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.31.tgz",
+      "integrity": "sha512-ymN2pj6zEjiKJZbrf98UM2pfDd6F2H7ksKw7NDt/ZZ1fh5Ei39X5tABugtT03ZRlWd9imccoK0hE8hpjpU7irQ=="
     },
     "node_modules/@vuelidate/core": {
       "version": "2.0.0-alpha.32",
@@ -2561,9 +2487,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "2.6.17",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-      "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
+      "version": "2.6.20",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
     },
     "node_modules/custom-event": {
       "version": "1.0.1",
@@ -5067,6 +4993,15 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
+    "node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-11.2.6.tgz",
@@ -5262,11 +5197,11 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dependencies": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "node_modules/make-error": {
@@ -5285,6 +5220,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -5341,6 +5307,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
     },
     "node_modules/meow": {
       "version": "8.1.2",
@@ -7730,6 +7702,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -7874,6 +7847,12 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
@@ -8258,15 +8237,6 @@
         "vscode-typescript-languageservice": "0.29.6"
       }
     },
-    "node_modules/vscode-vue-languageservice/node_modules/@vue/reactivity": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.22.tgz",
-      "integrity": "sha512-xNkLAItjI0xB+lFeDgKCrSItmrHTaAzSnt8LmdSCPQnDyarmzbi/u4ESQnckWvlL7lSRKiEaOvblaNyqAa7OnQ==",
-      "dev": true,
-      "dependencies": {
-        "@vue/shared": "3.2.22"
-      }
-    },
     "node_modules/vscode-vue-languageservice/node_modules/@vue/shared": {
       "version": "3.2.22",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.22.tgz",
@@ -8274,13 +8244,15 @@
       "dev": true
     },
     "node_modules/vue": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.6.tgz",
-      "integrity": "sha512-Zlb3LMemQS3Xxa6xPsecu45bNjr1hxO8Bh5FUmE0Dr6Ot0znZBKiM47rK6O7FTcakxOnvVN+NTXWJF6u8ajpCQ==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.31.tgz",
+      "integrity": "sha512-odT3W2tcffTiQCy57nOT93INw1auq5lYLLYtWpPYQQYQOOdHiqFct9Xhna6GJ+pJQaF67yZABraH47oywkJgFw==",
       "dependencies": {
-        "@vue/compiler-dom": "3.2.6",
-        "@vue/runtime-dom": "3.2.6",
-        "@vue/shared": "3.2.6"
+        "@vue/compiler-dom": "3.2.31",
+        "@vue/compiler-sfc": "3.2.31",
+        "@vue/runtime-dom": "3.2.31",
+        "@vue/server-renderer": "3.2.31",
+        "@vue/shared": "3.2.31"
       }
     },
     "node_modules/vue-eslint-parser": {
@@ -8833,7 +8805,8 @@
     "@babel/helper-validator-identifier": {
       "version": "7.15.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "dev": true
     },
     "@babel/helper-validator-option": {
       "version": "7.14.5",
@@ -8968,6 +8941,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
       "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
@@ -9659,28 +9633,6 @@
         "upath": "^2.0.1"
       },
       "dependencies": {
-        "@vue/compiler-core": {
-          "version": "3.2.22",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.22.tgz",
-          "integrity": "sha512-uAkovrVeTcjzpiM4ECmVaMrv/bjdgAaLzvjcGqQPBEyUrcqsCgccT9fHJ/+hWVGhyMahmBwLqcn4guULNx7sdw==",
-          "dev": true,
-          "requires": {
-            "@babel/parser": "^7.15.0",
-            "@vue/shared": "3.2.22",
-            "estree-walker": "^2.0.2",
-            "source-map": "^0.6.1"
-          }
-        },
-        "@vue/compiler-dom": {
-          "version": "3.2.22",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.22.tgz",
-          "integrity": "sha512-VZdsw/VuO1ODs8K7NQwnMQzKITDkIFlYYC03SVnunuf6eNRxBPEonSyqbWNoo6qNaHAEBTG6VVcZC5xC9bAx1g==",
-          "dev": true,
-          "requires": {
-            "@vue/compiler-core": "3.2.22",
-            "@vue/shared": "3.2.22"
-          }
-        },
         "@vue/shared": {
           "version": "3.2.22",
           "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.22.tgz",
@@ -9712,104 +9664,49 @@
       }
     },
     "@vue/compiler-core": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.6.tgz",
-      "integrity": "sha512-vbwnz7+OhtLO5p5i630fTuQCL+MlUpEMTKHuX+RfetQ+3pFCkItt2JUH+9yMaBG2Hkz6av+T9mwN/acvtIwpbw==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.31.tgz",
+      "integrity": "sha512-aKno00qoA4o+V/kR6i/pE+aP+esng5siNAVQ422TkBNM6qA4veXiZbSe8OTXHXquEi/f6Akc+nLfB4JGfe4/WQ==",
       "requires": {
-        "@babel/parser": "^7.15.0",
-        "@babel/types": "^7.15.0",
-        "@vue/shared": "3.2.6",
+        "@babel/parser": "^7.16.4",
+        "@vue/shared": "3.2.31",
         "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.6.tgz",
-      "integrity": "sha512-+a/3oBAzFIXhHt8L5IHJOTP4a5egzvpXYyi13jR7CUYOR1S+Zzv7vBWKYBnKyJLwnrxTZnTQVjeHCgJq743XKg==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.31.tgz",
+      "integrity": "sha512-60zIlFfzIDf3u91cqfqy9KhCKIJgPeqxgveH2L+87RcGU/alT6BRrk5JtUso0OibH3O7NXuNOQ0cDc9beT0wrg==",
       "requires": {
-        "@vue/compiler-core": "3.2.6",
-        "@vue/shared": "3.2.6"
+        "@vue/compiler-core": "3.2.31",
+        "@vue/shared": "3.2.31"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.22.tgz",
-      "integrity": "sha512-tWRQ5ge1tsTDhUwHgueicKJ8rYm6WUVAPTaIpFW3GSwZKcOEJ2rXdfkHFShNVGupeRALz2ET2H84OL0GeRxY0A==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.31.tgz",
+      "integrity": "sha512-748adc9msSPGzXgibHiO6T7RWgfnDcVQD+VVwYgSsyyY8Ans64tALHZANrKtOzvkwznV/F4H7OAod/jIlp/dkQ==",
       "requires": {
-        "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.22",
-        "@vue/compiler-dom": "3.2.22",
-        "@vue/compiler-ssr": "3.2.22",
-        "@vue/ref-transform": "3.2.22",
-        "@vue/shared": "3.2.22",
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.31",
+        "@vue/compiler-dom": "3.2.31",
+        "@vue/compiler-ssr": "3.2.31",
+        "@vue/reactivity-transform": "3.2.31",
+        "@vue/shared": "3.2.31",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7",
         "postcss": "^8.1.10",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "@vue/compiler-core": {
-          "version": "3.2.22",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.22.tgz",
-          "integrity": "sha512-uAkovrVeTcjzpiM4ECmVaMrv/bjdgAaLzvjcGqQPBEyUrcqsCgccT9fHJ/+hWVGhyMahmBwLqcn4guULNx7sdw==",
-          "requires": {
-            "@babel/parser": "^7.15.0",
-            "@vue/shared": "3.2.22",
-            "estree-walker": "^2.0.2",
-            "source-map": "^0.6.1"
-          }
-        },
-        "@vue/compiler-dom": {
-          "version": "3.2.22",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.22.tgz",
-          "integrity": "sha512-VZdsw/VuO1ODs8K7NQwnMQzKITDkIFlYYC03SVnunuf6eNRxBPEonSyqbWNoo6qNaHAEBTG6VVcZC5xC9bAx1g==",
-          "requires": {
-            "@vue/compiler-core": "3.2.22",
-            "@vue/shared": "3.2.22"
-          }
-        },
-        "@vue/shared": {
-          "version": "3.2.22",
-          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.22.tgz",
-          "integrity": "sha512-qWVav014mpjEtbWbEgl0q9pEyrrIySKum8UVYjwhC6njrKzknLZPvfuYdQyVbApsqr94tf/3dP4pCuZmmjdCWQ=="
-        }
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.22.tgz",
-      "integrity": "sha512-Cl6aoLJtXzzBkk1sKod8S0WBJLts3+ugVC91d22gGpbkw/64WnF12tOZi7Rg54PPLi1NovqyNWPsLH/SAFcu+w==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.31.tgz",
+      "integrity": "sha512-mjN0rqig+A8TVDnsGPYJM5dpbjlXeHUm2oZHZwGyMYiGT/F4fhJf/cXy8QpjnLQK4Y9Et4GWzHn9PS8AHUnSkw==",
       "requires": {
-        "@vue/compiler-dom": "3.2.22",
-        "@vue/shared": "3.2.22"
-      },
-      "dependencies": {
-        "@vue/compiler-core": {
-          "version": "3.2.22",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.22.tgz",
-          "integrity": "sha512-uAkovrVeTcjzpiM4ECmVaMrv/bjdgAaLzvjcGqQPBEyUrcqsCgccT9fHJ/+hWVGhyMahmBwLqcn4guULNx7sdw==",
-          "requires": {
-            "@babel/parser": "^7.15.0",
-            "@vue/shared": "3.2.22",
-            "estree-walker": "^2.0.2",
-            "source-map": "^0.6.1"
-          }
-        },
-        "@vue/compiler-dom": {
-          "version": "3.2.22",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.22.tgz",
-          "integrity": "sha512-VZdsw/VuO1ODs8K7NQwnMQzKITDkIFlYYC03SVnunuf6eNRxBPEonSyqbWNoo6qNaHAEBTG6VVcZC5xC9bAx1g==",
-          "requires": {
-            "@vue/compiler-core": "3.2.22",
-            "@vue/shared": "3.2.22"
-          }
-        },
-        "@vue/shared": {
-          "version": "3.2.22",
-          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.22.tgz",
-          "integrity": "sha512-qWVav014mpjEtbWbEgl0q9pEyrrIySKum8UVYjwhC6njrKzknLZPvfuYdQyVbApsqr94tf/3dP4pCuZmmjdCWQ=="
-        }
+        "@vue/compiler-dom": "3.2.31",
+        "@vue/shared": "3.2.31"
       }
     },
     "@vue/devtools-api": {
@@ -9836,66 +9733,57 @@
       }
     },
     "@vue/reactivity": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.6.tgz",
-      "integrity": "sha512-8vIDD2wpCnYisNNZjmcIj+Rixn0uhZNY3G1vzlgdVdLygeRSuFjkmnZk6WwvGzUWpKfnG0e/NUySM3mVi59hAA==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.31.tgz",
+      "integrity": "sha512-HVr0l211gbhpEKYr2hYe7hRsV91uIVGFYNHj73njbARVGHQvIojkImKMaZNDdoDZOIkMsBc9a1sMqR+WZwfSCw==",
       "requires": {
-        "@vue/shared": "3.2.6"
+        "@vue/shared": "3.2.31"
       }
     },
-    "@vue/ref-transform": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.22.tgz",
-      "integrity": "sha512-qalVWbq5xWWxLZ0L9OroBg/JZhzavQuCcDXblfErxyDEH6Xc5gIJ4feo1SVCICFzhAUgLgQTdSFLpgjBawbFpw==",
+    "@vue/reactivity-transform": {
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.31.tgz",
+      "integrity": "sha512-uS4l4z/W7wXdI+Va5pgVxBJ345wyGFKvpPYtdSgvfJfX/x2Ymm6ophQlXXB6acqGHtXuBqNyyO3zVp9b1r0MOA==",
       "requires": {
-        "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.22",
-        "@vue/shared": "3.2.22",
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.31",
+        "@vue/shared": "3.2.31",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
-      },
-      "dependencies": {
-        "@vue/compiler-core": {
-          "version": "3.2.22",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.22.tgz",
-          "integrity": "sha512-uAkovrVeTcjzpiM4ECmVaMrv/bjdgAaLzvjcGqQPBEyUrcqsCgccT9fHJ/+hWVGhyMahmBwLqcn4guULNx7sdw==",
-          "requires": {
-            "@babel/parser": "^7.15.0",
-            "@vue/shared": "3.2.22",
-            "estree-walker": "^2.0.2",
-            "source-map": "^0.6.1"
-          }
-        },
-        "@vue/shared": {
-          "version": "3.2.22",
-          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.22.tgz",
-          "integrity": "sha512-qWVav014mpjEtbWbEgl0q9pEyrrIySKum8UVYjwhC6njrKzknLZPvfuYdQyVbApsqr94tf/3dP4pCuZmmjdCWQ=="
-        }
       }
     },
     "@vue/runtime-core": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.6.tgz",
-      "integrity": "sha512-3mqtgpj/YSGFxtvTufSERRApo92B16JNNxz9p+5eG6PPuqTmuRJz214MqhKBEgLEAIQ6R6YCbd83ZDtjQnyw2g==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.31.tgz",
+      "integrity": "sha512-Kcog5XmSY7VHFEMuk4+Gap8gUssYMZ2+w+cmGI6OpZWYOEIcbE0TPzzPHi+8XTzAgx1w/ZxDFcXhZeXN5eKWsA==",
       "requires": {
-        "@vue/reactivity": "3.2.6",
-        "@vue/shared": "3.2.6"
+        "@vue/reactivity": "3.2.31",
+        "@vue/shared": "3.2.31"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.6.tgz",
-      "integrity": "sha512-fq33urnP0BNCGm2O3KCzkJlKIHI80C94HJ4qDZbjsTtxyOn5IHqwKSqXVN3RQvO6epcQH+sWS+JNwcNDPzoasg==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.31.tgz",
+      "integrity": "sha512-N+o0sICVLScUjfLG7u9u5XCjvmsexAiPt17GNnaWHJUfsKed5e85/A3SWgKxzlxx2SW/Hw7RQxzxbXez9PtY3g==",
       "requires": {
-        "@vue/runtime-core": "3.2.6",
-        "@vue/shared": "3.2.6",
+        "@vue/runtime-core": "3.2.31",
+        "@vue/shared": "3.2.31",
         "csstype": "^2.6.8"
       }
     },
+    "@vue/server-renderer": {
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.31.tgz",
+      "integrity": "sha512-8CN3Zj2HyR2LQQBHZ61HexF5NReqngLT3oahyiVRfSSvak+oAvVmu8iNLSu6XR77Ili2AOpnAt1y8ywjjqtmkg==",
+      "requires": {
+        "@vue/compiler-ssr": "3.2.31",
+        "@vue/shared": "3.2.31"
+      }
+    },
     "@vue/shared": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.6.tgz",
-      "integrity": "sha512-uwX0Qs2e6kdF+WmxwuxJxOnKs/wEkMArtYpHSm7W+VY/23Tl8syMRyjnzEeXrNCAP0/8HZxEGkHJsjPEDNRuHw=="
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.31.tgz",
+      "integrity": "sha512-ymN2pj6zEjiKJZbrf98UM2pfDd6F2H7ksKw7NDt/ZZ1fh5Ei39X5tABugtT03ZRlWd9imccoK0hE8hpjpU7irQ=="
     },
     "@vuelidate/core": {
       "version": "2.0.0-alpha.32",
@@ -10567,9 +10455,9 @@
       "dev": true
     },
     "csstype": {
-      "version": "2.6.17",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-      "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A=="
+      "version": "2.6.20",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
+      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
     },
     "custom-event": {
       "version": "1.0.1",
@@ -12419,6 +12307,15 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
+    "linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "lint-staged": {
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-11.2.6.tgz",
@@ -12564,11 +12461,11 @@
       "dev": true
     },
     "magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "requires": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "make-error": {
@@ -12582,6 +12479,33 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
       "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
       "dev": true
+    },
+    "markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "entities": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+          "dev": true
+        }
+      }
     },
     "mathml-tag-names": {
       "version": "2.1.3",
@@ -12620,6 +12544,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
       "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "dev": true
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
       "dev": true
     },
     "meow": {
@@ -14445,7 +14375,8 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -14544,6 +14475,12 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
       "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "dev": true
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
     "unbox-primitive": {
@@ -14862,15 +14799,6 @@
         "vscode-typescript-languageservice": "0.29.6"
       },
       "dependencies": {
-        "@vue/reactivity": {
-          "version": "3.2.22",
-          "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.22.tgz",
-          "integrity": "sha512-xNkLAItjI0xB+lFeDgKCrSItmrHTaAzSnt8LmdSCPQnDyarmzbi/u4ESQnckWvlL7lSRKiEaOvblaNyqAa7OnQ==",
-          "dev": true,
-          "requires": {
-            "@vue/shared": "3.2.22"
-          }
-        },
         "@vue/shared": {
           "version": "3.2.22",
           "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.22.tgz",
@@ -14880,13 +14808,15 @@
       }
     },
     "vue": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.6.tgz",
-      "integrity": "sha512-Zlb3LMemQS3Xxa6xPsecu45bNjr1hxO8Bh5FUmE0Dr6Ot0znZBKiM47rK6O7FTcakxOnvVN+NTXWJF6u8ajpCQ==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.31.tgz",
+      "integrity": "sha512-odT3W2tcffTiQCy57nOT93INw1auq5lYLLYtWpPYQQYQOOdHiqFct9Xhna6GJ+pJQaF67yZABraH47oywkJgFw==",
       "requires": {
-        "@vue/compiler-dom": "3.2.6",
-        "@vue/runtime-dom": "3.2.6",
-        "@vue/shared": "3.2.6"
+        "@vue/compiler-dom": "3.2.31",
+        "@vue/compiler-sfc": "3.2.31",
+        "@vue/runtime-dom": "3.2.31",
+        "@vue/server-renderer": "3.2.31",
+        "@vue/shared": "3.2.31"
       }
     },
     "vue-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "googleapis": "^91.0.0",
     "husky": "^7.0.4",
     "lint-staged": "^11.1.2",
+    "markdown-it": "^12.3.2",
     "postcss": "^8.4.0",
     "prettier": "^2.4.1",
     "stylelint": "^13.13.0",

--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -50,6 +50,9 @@ const sheets = google.sheets({ version: 'v4', auth });
         }
         localeDataPart = localeDataPart[part];
       }
+      if (localeDataPart[lastKeyPart] !== undefined) {
+        console.log('Duplicate key ' + row.key);
+      }
       localeDataPart[lastKeyPart] = keyOpts.reduce(
         (data, opt) => optHandlers[opt](data),
         row[locale] || ''

--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -3,6 +3,13 @@
 const fs = require('fs');
 const path = require('path');
 const { google } = require('googleapis');
+const MarkdownIt = require('markdown-it');
+
+const simpleMd = new MarkdownIt('zero').enable(['emphasis']);
+
+const optHandlers = {
+  md: (data) => simpleMd.render(data),
+};
 
 const auth = new google.auth.GoogleAuth({
   keyFile: path.join(__dirname, '.credentials.json'),
@@ -33,7 +40,8 @@ const sheets = google.sheets({ version: 'v4', auth });
   // Construct nested objects from a.b.c key paths
   for (const row of rows) {
     const keyParts = row.key.split('.');
-    const lastKeyPart = keyParts.pop();
+    const [lastKeyPart, ...keyOpts] = keyParts.pop().split(':');
+
     for (const locale of locales) {
       let localeDataPart = localeData[locale];
       for (const part of keyParts) {
@@ -42,7 +50,10 @@ const sheets = google.sheets({ version: 'v4', auth });
         }
         localeDataPart = localeDataPart[part];
       }
-      localeDataPart[lastKeyPart] = row[locale];
+      localeDataPart[lastKeyPart] = keyOpts.reduce(
+        (data, opt) => optHandlers[opt](data),
+        row[locale] || ''
+      );
     }
   }
 

--- a/src/modules/contacts/pages/ContactOverviewPage.vue
+++ b/src/modules/contacts/pages/ContactOverviewPage.vue
@@ -77,11 +77,7 @@
     </div>
     <div class="row-span-3 max-w-xl">
       <AppHeading>{{ t('contactOverview.about') }}</AppHeading>
-      <p class="mb-5">
-        {{ t('contactOverview.annotation.copy.begin') }}
-        <b>{{ t('contactOverview.annotation.copy.bold') }}</b>
-        {{ t('contactOverview.annotation.copy.end') }}
-      </p>
+      <div class="mb-5" v-html="t('contactOverview.annotation.copy')" />
 
       <form @submit.prevent="handleFormSubmit">
         <AppInput


### PR DESCRIPTION
Add the ability to add limited markdown functionality (currently just emphasis) for i18n strings so we don't have to split strings that just need a bit of bold into lots of separate keys

To enable markdown for a key add `:md` to the end of the key, e.g.
`contactOverview.annotation.copy` becomes `contactOverview.annotation.copy:md`