### PR TITLE
feat: add callouts admin list page

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -25,6 +25,12 @@
     "showAll": "Alle",
     "showAnswered": "Beantwortet"
   },
+  "calloutsAdmin": {
+    "data": {
+      "status": "Status"
+    },
+    "filter": {}
+  },
   "common": {
     "annually": "Jährlich",
     "backToHome": "Zurück zur Startseite",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -25,6 +25,12 @@
     "showAll": "Alle",
     "showAnswered": "Beantwortet"
   },
+  "calloutsAdmin": {
+    "data": {
+      "status": "Status"
+    },
+    "filter": {}
+  },
   "common": {
     "annually": "Jährlich",
     "backToHome": "Zurück zur Startseite",

--- a/locales/en.json
+++ b/locales/en.json
@@ -28,6 +28,23 @@
     "showAll": "All",
     "showAnswered": "Answered"
   },
+  "calloutsAdmin": {
+    "addCallout": "Create callout",
+    "data": {
+      "expires": "Expiry date",
+      "responses": "Responses",
+      "starts": "Start date",
+      "status": "Status",
+      "title": "Title"
+    },
+    "filter": {
+      "all": "All callouts",
+      "draft": "Draft callouts",
+      "ended": "Ended callouts",
+      "open": "Open callouts",
+      "scheduled": "Scheduled callouts"
+    }
+  },
   "common": {
     "annually": "Annually",
     "backToHome": "Back to home",

--- a/src/components/AppItemStatus.vue
+++ b/src/components/AppItemStatus.vue
@@ -11,7 +11,7 @@ const color = {
   draft: 'text-body-40',
   scheduled: 'text-warning',
   open: 'text-success',
-  ended: 'text-body',
+  ended: 'text-body-80',
 };
 defineProps<{
   status: ItemStatus;

--- a/src/components/table/AppTable.vue
+++ b/src/components/table/AppTable.vue
@@ -5,7 +5,7 @@
         <th
           v-for="(header, i) in headers"
           :key="i"
-          class="p-2 relative"
+          class="p-2 relative whitespace-nowrap"
           :class="{ 'cursor-pointer': header.sortable }"
           :align="header.align || 'left'"
           :style="{ width: header.width }"

--- a/src/components/table/AppTable.vue
+++ b/src/components/table/AppTable.vue
@@ -5,7 +5,7 @@
         <th
           v-for="(header, i) in headers"
           :key="i"
-          class="p-2 relative whitespace-nowrap"
+          class="p-2 relative whitespace-nowrap font-semibold text-body-80"
           :class="{ 'cursor-pointer': header.sortable }"
           :align="header.align || 'left'"
           :style="{ width: header.width }"

--- a/src/components/table/AppTable.vue
+++ b/src/components/table/AppTable.vue
@@ -31,7 +31,7 @@
         <td
           v-for="(header, j) in headers"
           :key="j"
-          class="p-2 align-top"
+          class="p-2 align-bottom"
           :align="header.align || undefined"
         >
           <slot :name="header.value" :item="item" :value="item[header.value]">{{

--- a/src/components/table/AppTable.vue
+++ b/src/components/table/AppTable.vue
@@ -6,7 +6,10 @@
           v-for="(header, i) in headers"
           :key="i"
           class="p-2 relative whitespace-nowrap font-semibold text-body-80"
-          :class="{ 'cursor-pointer': header.sortable }"
+          :class="{
+            'cursor-pointer': header.sortable,
+            'font-bold text-primary': header.value === sort?.by,
+          }"
           :align="header.align || 'left'"
           :style="{ width: header.width }"
           @click="sortBy(header)"

--- a/src/modules/callouts/callouts.route.ts
+++ b/src/modules/callouts/callouts.route.ts
@@ -21,4 +21,13 @@ export const calloutsRoute: Array<RouteRecordRaw> = [
       noAuth: true,
     },
   },
+  {
+    path: '/admin/callouts',
+    name: 'calloutsAdmin',
+    component: () => import('./pages/CalloutsAdminPage.vue'),
+    meta: {
+      pageTitle: t('menu.callouts'),
+      role: 'admin',
+    },
+  },
 ];

--- a/src/modules/callouts/pages/CalloutsAdminPage.vue
+++ b/src/modules/callouts/pages/CalloutsAdminPage.vue
@@ -41,7 +41,7 @@
         </template>
         <template #hidden="{ value }">
           <font-awesome-icon
-            :class="!value && 'text-body-40'"
+            :class="value ? 'text-body-80' : 'text-body-40'"
             :icon="value ? 'eye-slash' : 'eye'"
           />
         </template>

--- a/src/modules/callouts/pages/CalloutsAdminPage.vue
+++ b/src/modules/callouts/pages/CalloutsAdminPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mb-5 flex justify-between border-primary-40 border-b pb-3">
     <PageTitle :title="t('menu.callouts')"></PageTitle>
-    <div class="flex-1 md:hidden">
+    <div class="flex-1 block lg:hidden">
       <AppSelect v-model="currentStatus" :items="statusItems" />
     </div>
     <div class="flex-0 ml-3">
@@ -11,7 +11,7 @@
     </div>
   </div>
   <div class="md:flex">
-    <div class="flex-none hidden md:block basis-[220px]">
+    <div class="flex-none hidden lg:block basis-[220px]">
       <AppVTabs v-model="currentStatus" :items="statusItems" />
     </div>
     <div class="flex-auto">
@@ -47,12 +47,12 @@
         </template>
         <template #starts="{ value }">
           <span class="whitespace-nowrap">{{
-            value && formatLocale(value, 'PPP')
+            value && formatLocale(value, 'PP')
           }}</span>
         </template>
         <template #expires="{ value }">
           <span class="whitespace-nowrap">{{
-            value && formatLocale(value, 'PPP')
+            value && formatLocale(value, 'PP')
           }}</span>
         </template>
       </AppTable>

--- a/src/modules/callouts/pages/CalloutsAdminPage.vue
+++ b/src/modules/callouts/pages/CalloutsAdminPage.vue
@@ -1,0 +1,229 @@
+<template>
+  <div class="mb-5 flex justify-between border-primary-40 border-b pb-3">
+    <PageTitle :title="t('menu.callouts')"></PageTitle>
+    <div class="flex-1 md:hidden">
+      <AppSelect v-model="currentStatus" :items="statusItems" />
+    </div>
+    <div class="flex-0 ml-3">
+      <AppButton href="/tools/polls">{{
+        t('calloutsAdmin.addCallout')
+      }}</AppButton>
+    </div>
+  </div>
+  <div class="md:flex">
+    <div class="flex-none hidden md:block basis-[220px]">
+      <AppVTabs v-model="currentStatus" :items="statusItems" />
+    </div>
+    <div class="flex-auto">
+      <div class="flex">
+        <AppSearchInput
+          v-model="currentSearch"
+          :placeholder="t('callouts.search')"
+        />
+      </div>
+      <AppTable
+        v-model:sort="currentSort"
+        :headers="headers"
+        :items="calloutsTable.items"
+        class="w-full mt-2"
+      >
+        <template #header-hidden><font-awesome-icon icon="eye" /></template>
+        <template #status="{ value }">
+          <AppItemStatus :status="value" />
+        </template>
+        <template #title="{ item, value }">
+          <a
+            :href="'/tools/polls/' + item.slug"
+            class="text-base text-link font-bold"
+          >
+            {{ value }}
+          </a>
+        </template>
+        <template #hidden="{ value }">
+          <font-awesome-icon
+            :class="!value && 'text-body-40'"
+            :icon="value ? 'eye-slash' : 'eye'"
+          />
+        </template>
+        <template #starts="{ value }">
+          <span class="whitespace-nowrap">{{
+            value && formatLocale(value, 'PPP')
+          }}</span>
+        </template>
+        <template #expires="{ value }">
+          <span class="whitespace-nowrap">{{
+            value && formatLocale(value, 'PPP')
+          }}</span>
+        </template>
+      </AppTable>
+      <div class="mt-4 flex justify-end">
+        <AppPagination v-model="currentPage" :total-pages="totalPages" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref, watchEffect } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRoute, useRouter } from 'vue-router';
+import { Header, SortType } from '../../../components/table/table.interface';
+import AppButton from '../../../components/forms/AppButton.vue';
+import PageTitle from '../../../components/PageTitle.vue';
+import AppTable from '../../../components/table/AppTable.vue';
+import AppPagination from '../../../components/AppPagination.vue';
+import AppItemStatus from '../../../components/AppItemStatus.vue';
+import {
+  Paginated,
+  GetBasicCalloutData,
+  GetCalloutsQuery,
+} from '../../../utils/api/api.interface';
+import { formatLocale } from '../../../utils/dates/locale-date-formats';
+import { fetchCallouts } from '../../../utils/api/callout';
+
+import AppSelect from '../../../components/forms/AppSelect.vue';
+import AppSearchInput from '../../../components/forms/AppSearchInput.vue';
+import AppVTabs from '../../../components/tabs/AppVTabs.vue';
+
+const { t } = useI18n();
+
+const statusItems = [
+  {
+    id: '',
+    label: t('calloutsAdmin.filter.all'),
+    to: '/admin/callouts',
+  },
+  {
+    id: 'open',
+    label: t('calloutsAdmin.filter.open'),
+    to: '/admin/callouts?filter=open',
+  },
+  {
+    id: 'scheduled',
+    label: t('calloutsAdmin.filter.scheduled'),
+    to: '/admin/callouts?filter=scheduled',
+  },
+  {
+    id: 'ended',
+    label: t('calloutsAdmin.filter.ended'),
+    to: '/admin/callouts?filter=ended',
+  },
+  {
+    id: 'draft',
+    label: t('calloutsAdmin.filter.draft'),
+    to: '/admin/callouts?filter=draft',
+  },
+];
+
+const headers: Header[] = [
+  {
+    value: 'status',
+    text: t('calloutsAdmin.data.status'),
+  },
+  {
+    value: 'title',
+    text: t('calloutsAdmin.data.title'),
+    sortable: true,
+    width: '100%',
+  },
+  {
+    value: 'hidden',
+    text: '',
+  },
+  {
+    value: 'starts',
+    text: t('calloutsAdmin.data.starts'),
+    align: 'right',
+    sortable: true,
+  },
+  {
+    value: 'expires',
+    text: t('calloutsAdmin.data.expires'),
+    align: 'right',
+    sortable: true,
+  },
+];
+
+const route = useRoute();
+const router = useRouter();
+
+const currentPageSize = computed({
+  get: () => Number(route.query.limit) || 25,
+  set: (limit) => router.push({ query: { ...route.query, limit } }),
+});
+
+const currentPage = computed({
+  get: () => Number(route.query.page) || 0,
+  set: (page) => router.push({ query: { ...route.query, page } }),
+});
+
+const currentSort = computed({
+  get: () => ({
+    by: (route.query.sortBy as string) || 'starts',
+    type: (route.query.sortType as SortType) || SortType.Desc,
+  }),
+  set: ({ by, type }) => {
+    router.replace({
+      query: {
+        ...route.query,
+        sortBy: by,
+        sortType: type,
+      },
+    });
+  },
+});
+
+const currentSearch = computed({
+  get: () => (route.query.s as string) || '',
+  set: (s) => router.push({ query: { ...route.query, s } }),
+});
+
+const currentStatus = computed({
+  get: () => (route.query.filter as string) || '',
+  set: (filter) => router.push({ query: { ...route.query, filter } }),
+});
+
+const calloutsTable = ref<Paginated<GetBasicCalloutData>>({
+  total: 0,
+  count: 0,
+  offset: 0,
+  items: [],
+});
+
+const totalPages = computed(() =>
+  Math.ceil(calloutsTable.value.total / currentPageSize.value)
+);
+
+watchEffect(async () => {
+  const rules = {
+    condition: 'AND',
+    rules: [
+      ...(currentStatus.value
+        ? [
+            {
+              field: 'status',
+              operator: 'equal',
+              value: currentStatus.value,
+            },
+          ]
+        : []),
+      ...(currentSearch.value
+        ? [
+            {
+              field: 'title' as const,
+              operator: 'contains',
+              value: currentSearch.value,
+            },
+          ]
+        : []),
+    ],
+  } as NonNullable<GetCalloutsQuery['rules']>;
+  calloutsTable.value = await fetchCallouts({
+    limit: currentPageSize.value,
+    offset: currentPage.value * currentPageSize.value,
+    sort: currentSort.value.by,
+    order: currentSort.value.type,
+    rules: rules.rules.length > 0 ? rules : undefined,
+  });
+});
+</script>

--- a/src/modules/notices/NoticesPage.vue
+++ b/src/modules/notices/NoticesPage.vue
@@ -23,7 +23,7 @@
       </a>
     </template>
     <template #createdAt="{ value }">
-      <span class="whitespace-nowrap">{{ formatLocale(value, 'PPP') }}</span>
+      <span class="whitespace-nowrap">{{ formatLocale(value, 'PP') }}</span>
     </template>
   </AppTable>
   <div class="mt-4 ml-auto">

--- a/src/modules/notices/notices.route.ts
+++ b/src/modules/notices/notices.route.ts
@@ -5,7 +5,7 @@ const { t } = i18n.global;
 
 export const noticesRoute: Array<RouteRecordRaw> = [
   {
-    path: '/notices',
+    path: '/admin/notices',
     component: () => import('./NoticesPage.vue'),
     meta: {
       layout: 'Dashboard',

--- a/src/plugins/icons.ts
+++ b/src/plugins/icons.ts
@@ -26,6 +26,8 @@ import {
   faSearch,
   faShare,
   faThumbsUp,
+  faEye,
+  faEyeSlash,
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(
@@ -52,7 +54,9 @@ library.add(
   faUsers,
   faSearch,
   faShare,
-  faThumbsUp
+  faThumbsUp,
+  faEye,
+  faEyeSlash
 );
 
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';


### PR DESCRIPTION
One change from spec:
* Eye icon is `text-body-40` when the callout is not hidden (rather than when hidden), I think we should be highlighting when a callout is hidden not the other way round.

A couple of things deferred for simplicity that I will add to the backlog:
* Count next to each status (open, scheduled, etc.)
* Number of responses per callout

![image](https://user-images.githubusercontent.com/2084823/160449059-a8ae7723-45a9-4530-b79c-90ce081c9f36.png)
