### PR TITLE
feat: refactor nav and add admin menu

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -286,7 +286,7 @@
     "wrongCredentials": "Falsche Kombination von Passwort und Email."
   },
   "menu": {
-    "admin": "Administrator",
+    "admin": "Administration",
     "adminDashboard": "Dashboard",
     "callouts": "Callouts",
     "community": "Community",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -286,7 +286,7 @@
     "wrongCredentials": "Falsche Kombination von Passwort und Email."
   },
   "menu": {
-    "admin": "Administrator",
+    "admin": "Administration",
     "adminDashboard": "Dashboard",
     "callouts": "Callouts",
     "community": "Community",

--- a/locales/en.json
+++ b/locales/en.json
@@ -300,7 +300,7 @@
     "wrongCredentials": "Wrong password/email combination"
   },
   "menu": {
-    "admin": "Admin",
+    "admin": "Administration",
     "adminDashboard": "Dashboard",
     "callouts": "Callouts",
     "community": "Community",

--- a/src/layouts/menu/TheMenu.vue
+++ b/src/layouts/menu/TheMenu.vue
@@ -14,7 +14,7 @@
         right-0
         opacity-30
         bg-black
-        left-[240px]
+        left-menu
       "
       :class="isMenuVisible ? 'block' : 'hidden'"
       @click="isMenuVisible = false"
@@ -45,7 +45,6 @@
       z-40
       md:static
       flex flex-col
-      px-4
       bottom-0
       bg-white
       transform
@@ -53,7 +52,7 @@
       -translate-x-full
       md:transform-none
       flex-none
-      w-[240px]
+      w-menu
     "
     :class="{ 'top-[68px] translate-x-0': isMenuVisible }"
   >
@@ -66,7 +65,7 @@
       />
     </div>
 
-    <TheMenuList v-if="currentUser" :sections="menuSections" />
+    <TheMenuList v-if="currentUser" />
   </div>
 </template>
 
@@ -74,8 +73,6 @@
 import { ref } from '@vue/reactivity';
 import { useRoute, useRouter } from 'vue-router';
 import { currentUser, generalContent } from '../../store';
-
-import menuSections from './menu-list';
 import TheMenuList from './TheMenuList.vue';
 
 const route = useRoute();

--- a/src/layouts/menu/TheMenuList.vue
+++ b/src/layouts/menu/TheMenuList.vue
@@ -1,36 +1,32 @@
 <template>
   <div class="flex-auto">
-    <nav
-      v-for="(section, index) in sections"
+    <TheMenuListSection
+      v-for="(section, index) in menu"
       :key="index"
-      class="menu-section"
-      :class="{ 'is-settings': section.type === 'settings' }"
-    >
-      <div v-if="index !== 0" class="menu-title">
-        {{ section.title }}
+      :section="section"
+      :is-first="index === 0"
+    />
+    <div v-if="canAdmin" class="bg-primary-10 py-4 mt-4">
+      <TheMenuListSection
+        v-for="(section, index) in adminMenu"
+        :key="index"
+        :section="section"
+        :is-first="index === 0"
+      />
+      <div class="mx-4">
+        <a href="/members">
+          <TheMenuListItem
+            :icon="['fa', 'cogs']"
+            :title="t('menu.adminDashboard')"
+          />
+        </a>
       </div>
-      <ul class="flex flex-col">
-        <template v-for="(item, itemIndex) in section.items" :key="itemIndex">
-          <li v-if="!item.role || currentUserCan(item.role).value">
-            <router-link class="menu-item" :to="item.href">
-              <TheMenuListItem :icon="item.icon" :title="item.title" />
-            </router-link>
-          </li>
-        </template>
-      </ul>
-    </nav>
-    <nav v-if="canAdmin" class="menu-section is-settings">
-      <div class="menu-title">{{ t('menu.admin') }}</div>
-      <a href="/members" class="menu-item cursor-pointer">
-        <TheMenuListItem
-          :icon="['fa', 'users']"
-          :title="t('menu.adminDashboard')"
-        />
-      </a>
-    </nav>
+    </div>
   </div>
-  <div class="menu-logout">
-    <a class="menu-item cursor-pointer" @click="doLogout">
+  <div
+    class="fixed bottom-0 left-0 p-4 border-t border-primary-40 bg-white w-menu"
+  >
+    <a class="cursor-pointer" @click="doLogout">
       <TheMenuListItem
         :icon="['fa', 'sign-in-alt']"
         :title="t('menu.logout')"
@@ -42,16 +38,16 @@
 <script lang="ts" setup>
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
-import { MenuSection } from './menu-list.interface';
-import currentUserCan, { canAdmin } from '../../utils/currentUserCan';
 import TheMenuListItem from './TheMenuListItem.vue';
+import TheMenuListSection from './TheMenuListSection.vue';
+import { canAdmin } from '../../utils/currentUserCan';
 import { logout } from '../../utils/api/auth';
 
-const { t } = useI18n();
+import { menu, adminMenu } from './menu-list';
 
-defineProps<{
-  sections: MenuSection[];
-}>();
+adminMenu;
+
+const { t } = useI18n();
 
 const router = useRouter();
 const doLogout = () => {
@@ -59,39 +55,3 @@ const doLogout = () => {
   router.push('/auth/login');
 };
 </script>
-
-<style scoped>
-.menu-section {
-  @apply text-primary-80;
-}
-
-.menu-title {
-  @apply py-1.5 border-t border-primary-40;
-}
-
-.menu-item {
-  @apply px-1 py-1.5 mb-1.5 rounded flex items-center hover:bg-primary-5 font-semibold;
-
-  &.router-link-active {
-    @apply bg-primary-20;
-  }
-}
-
-.menu-section.is-settings {
-  @apply text-grey-dark;
-
-  & .menu-item {
-    @apply hover:bg-grey-lighter;
-
-    &.router-link-active {
-      @apply bg-primary-5 text-grey-darker;
-    }
-  }
-}
-
-.menu-logout {
-  @apply fixed bottom-0 left-0 p-4 border-t border-primary-40 bg-white;
-
-  width: 240px;
-}
-</style>

--- a/src/layouts/menu/TheMenuList.vue
+++ b/src/layouts/menu/TheMenuList.vue
@@ -45,8 +45,6 @@ import { logout } from '../../utils/api/auth';
 
 import { menu, adminMenu } from './menu-list';
 
-adminMenu;
-
 const { t } = useI18n();
 
 const router = useRouter();

--- a/src/layouts/menu/TheMenuListItem.vue
+++ b/src/layouts/menu/TheMenuListItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="px-1 py-1.5 mb-2 rounded flex items-center font-semibold last:mb-0"
-    :class="itemClasses"
+    :class="itemClass"
   >
     <font-awesome-icon
       class="inline-block mr-2 h-4 fa-fw"
@@ -28,19 +28,16 @@ const props = withDefaults(
   }
 );
 
-const itemClasses = computed(
-  () =>
-    ((
-      {
-        main: [
-          'text-primary-80 hover:bg-primary-5',
-          'text-primary-80 bg-primary-20',
-        ],
-        settings: [
-          'text-grey-dark hover:bg-grey-lighter',
-          'bg-primary-5 text-grey-darker',
-        ],
-      } as const
-    )[props.type][props.isActive ? 1 : 0])
+// Different nav item styles: tuple is [normal, active] classes
+const itemClasses = {
+  main: ['text-primary-80 hover:bg-primary-5', 'text-primary-80 bg-primary-20'],
+  settings: [
+    'text-grey-dark hover:bg-grey-lighter',
+    'bg-primary-5 text-grey-darker',
+  ],
+} as const;
+
+const itemClass = computed(
+  () => itemClasses[props.type][props.isActive ? 1 : 0]
 );
 </script>

--- a/src/layouts/menu/TheMenuListItem.vue
+++ b/src/layouts/menu/TheMenuListItem.vue
@@ -1,16 +1,46 @@
 <template>
-  <font-awesome-icon
-    class="inline-block mr-2 h-4 fa-fw"
-    :icon="icon"
-    size="lg"
-  />
+  <div
+    class="px-1 py-1.5 mb-2 rounded flex items-center font-semibold last:mb-0"
+    :class="itemClasses"
+  >
+    <font-awesome-icon
+      class="inline-block mr-2 h-4 fa-fw"
+      :icon="icon"
+      size="lg"
+    />
 
-  <span>{{ title }}</span>
+    <span>{{ title }}</span>
+  </div>
 </template>
 
 <script lang="ts" setup>
-defineProps<{
-  title: string;
-  icon: [string, string];
-}>();
+import { computed } from 'vue';
+
+const props = withDefaults(
+  defineProps<{
+    title: string;
+    icon: [string, string];
+    type?: 'main' | 'settings';
+    isActive?: boolean;
+  }>(),
+  {
+    type: 'main',
+  }
+);
+
+const itemClasses = computed(
+  () =>
+    ((
+      {
+        main: [
+          'text-primary-80 hover:bg-primary-5',
+          'text-primary-80 bg-primary-20',
+        ],
+        settings: [
+          'text-grey-dark hover:bg-grey-lighter',
+          'bg-primary-5 text-grey-darker',
+        ],
+      } as const
+    )[props.type][props.isActive ? 1 : 0])
+);
 </script>

--- a/src/layouts/menu/TheMenuListSection.vue
+++ b/src/layouts/menu/TheMenuListSection.vue
@@ -1,0 +1,41 @@
+<template>
+  <nav
+    class="px-4"
+    :class="section.type === 'main' ? 'text-primary-80' : 'text-grey-dark'"
+  >
+    <div v-if="!isFirst" class="border-t border-primary-40 my-2" />
+    <div v-if="section.title" class="pb-2">
+      {{ section.title }}
+    </div>
+    <ul class="flex flex-col">
+      <template v-for="item in section.items" :key="item.href">
+        <li>
+          <router-link :to="item.href">
+            <TheMenuListItem
+              :icon="item.icon"
+              :title="item.title"
+              :type="section.type"
+              :is-active="
+                item.isActive
+                  ? item.isActive.test(route.path)
+                  : item.href === route.path
+              "
+            />
+          </router-link>
+        </li>
+      </template>
+    </ul>
+  </nav>
+</template>
+<script lang="ts" setup>
+import { useRoute } from 'vue-router';
+import { MenuSection } from './menu-list.interface';
+import TheMenuListItem from './TheMenuListItem.vue';
+
+defineProps<{
+  section: MenuSection;
+  isFirst: boolean;
+}>();
+
+const route = useRoute();
+</script>

--- a/src/layouts/menu/menu-list.interface.ts
+++ b/src/layouts/menu/menu-list.interface.ts
@@ -1,8 +1,6 @@
-import { PermissionType } from '../../utils/api/api.interface';
-
 export interface MenuSection {
   title?: string;
-  type?: 'settings';
+  type: 'main' | 'settings';
   items: MenuItem[];
 }
 
@@ -10,5 +8,5 @@ export interface MenuItem {
   title: string;
   href?: string;
   icon: [string, string];
-  role?: PermissionType;
+  isActive?: RegExp;
 }

--- a/src/layouts/menu/menu-list.ts
+++ b/src/layouts/menu/menu-list.ts
@@ -2,8 +2,9 @@ import i18n from '../../i18n';
 import { MenuSection } from './menu-list.interface';
 const { t } = i18n.global;
 
-export default [
+export const menu: MenuSection[] = [
   {
+    type: 'main',
     items: [
       {
         title: t('menu.home'),
@@ -19,13 +20,8 @@ export default [
         title: t('menu.callouts'),
         href: '/callouts',
         icon: ['far', 'calendar-check'],
+        isActive: /^\/callouts/,
       },*/
-      {
-        title: t('menu.community'),
-        href: '/contacts',
-        icon: ['fa', 'users'],
-        role: 'admin',
-      },
     ],
   },
   {
@@ -44,4 +40,31 @@ export default [
       },
     ],
   },
-] as MenuSection[];
+];
+
+export const adminMenu: MenuSection[] = [
+  {
+    type: 'main',
+    title: t('menu.admin'),
+    items: [
+      {
+        title: t('menu.community'),
+        href: '/contacts',
+        icon: ['fa', 'users'],
+        isActive: /^\/contacts.*/,
+      },
+      {
+        title: t('menu.callouts'),
+        href: '/admin/callouts',
+        icon: ['far', 'calendar-check'],
+        isActive: /^\/admin\/callouts.*/,
+      },
+      {
+        title: t('menu.notices'),
+        href: '/admin/notices',
+        icon: ['fa', 'bullhorn'],
+        isActive: /^\/admin\/notices.*/,
+      },
+    ],
+  },
+];

--- a/src/plugins/icons.ts
+++ b/src/plugins/icons.ts
@@ -28,6 +28,7 @@ import {
   faThumbsUp,
   faEye,
   faEyeSlash,
+  faCogs,
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(
@@ -56,7 +57,8 @@ library.add(
   faShare,
   faThumbsUp,
   faEye,
-  faEyeSlash
+  faEyeSlash,
+  faCogs
 );
 
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -63,6 +63,9 @@ module.exports = {
       padding: {
         4.5: '1.125rem',
       },
+      spacing: {
+        menu: '240px',
+      },
       height: {
         7.5: '1.875rem',
       },


### PR DESCRIPTION
Implementation of the admin nav. I have used this as an opportunity to refactor the menu code:

* Remove magic 240px by adding it as a `menu` spacing option to Tailwind
* Reworked how styles are applied so there is no custom CSS
* Separated sections out into into separate components

![image](https://user-images.githubusercontent.com/2084823/160826495-fb8fae14-234d-4bc2-bf86-3910c7679957.png)
