### PR TITLE
feat: dashboard notice for when there's no latest callout

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -1,22 +1,27 @@
 {
   "adminDashboard": {
-    "joinSlack": "",
+    "hint1": "<p>Das beabee-Handbuch für Community-Journalismus [„Lust auf Lokal” ist erschienen](https://beabee.io/neu-handbuch-community-journalismus/). Es enthält nicht nur unser gesammeltes Wissen zum Aufbau unabhängiger Lokalredaktionen, sondern auch viele Beispiele aus der Praxis.</p>\n",
+    "hint2": "<p>Kennst du schon unseren [Kurs für die Reporterfabrik](https://beabee.io/online-kurs-fuer-community-journalismus/) von CORRECTIV? Dort lernst du Schritt für Schritt, wie Community-Journalismus funktioniert.</p>\n",
+    "hint3": "<p>Unsere Community-Meetups finden jeden dritten Donnerstag im Monat statt. Du willst dein Best-Practice-Beispiel mit anderen teilen? Schreib eine E-Mail an [tobias.hauswurz@correctiv.org](mailto:tobias.hauswurz@correctiv.org)</p>\n",
+    "joinSlack": "Tritt der beabee-Community auf Slack bei!",
     "latestCallout": {
-      "title": ""
+      "createNew": "",
+      "empty": "",
+      "title": "Letzer Callout"
     },
     "mostRecentMembers": {
-      "title": ""
+      "title": "Neueste Mitglieder"
     },
     "numbers": {
-      "averageContribution": "",
-      "newMembers": "",
-      "revenue": "",
-      "title": ""
+      "averageContribution": "Durchschn. monatlicher Beitrag",
+      "newMembers": "Neue Mitglieder",
+      "revenue": "Einnahmen",
+      "title": "Überblick der letzten 30 Tage"
     },
-    "responsesSoFar": "",
-    "seeAllResponses": "",
-    "supportInbox": "",
-    "welcomeBack": ""
+    "responsesSoFar": "Antworten bisher",
+    "seeAllResponses": "Alle Antworten anzeigen",
+    "supportInbox": "Benötigst du Hilfe? Schreib' uns eine E-Mail an:",
+    "welcomeBack": "Willkommen zurück {firstName}!"
   },
   "callout": {
     "contactDetails": "Kontaktdaten",
@@ -42,13 +47,13 @@
   },
   "calloutAdminOverview": {
     "actions": {
-      "delete": "",
-      "edit": "",
-      "replicate": "",
-      "unpublish": "",
-      "view": ""
+      "delete": "Löschen",
+      "edit": "Bearbeiten",
+      "replicate": "Kopieren",
+      "unpublish": "Veröffentlichung aufheben",
+      "view": "Anzeigen"
     },
-    "created": "",
+    "created": "Gut gemacht! Dein Callout wurde erstellt.",
     "dates": {
       "ends": "Ende",
       "label": "Termine",
@@ -232,10 +237,10 @@
   },
   "createCallout": {
     "actions": {
-      "back": "",
-      "continue": "",
-      "publish": "",
-      "schedule": ""
+      "back": "Zurück",
+      "continue": "Weiter",
+      "publish": "Veröffentlichen",
+      "schedule": "Planen"
     },
     "steps": {
       "content": {
@@ -298,8 +303,8 @@
         "title": "Nachricht am Ende"
       },
       "mailchimp": {
-        "description": "",
-        "title": ""
+        "description": "Mailchimp-Synchronisation einrichten",
+        "title": "Mailchimp-Synchronisation"
       },
       "titleAndImage": {
         "description": "Gib deinem Callout eine Titel, eine Beschreibung und ein Bild.",
@@ -331,18 +336,18 @@
             "placeholder": "Erkläre kurz und knapp, warum Menschen an dem Callout teilnehmen sollten."
           },
           "overrideShare": {
-            "label": "",
+            "label": "Callout-Titel und -Beschreibung zum Teilen verwenden?",
             "opts": {
-              "no": "",
-              "yes": ""
+              "no": "Nein, Titel und Beschreibung selbst festlegen",
+              "yes": "Ja"
             }
           },
           "slug": {
             "help": "<p>Die URL-Endung wird für die Webadresse des Callouts benötigt.</p>\n",
             "label": "URL-Endung",
             "opts": {
-              "auto": "",
-              "manual": ""
+              "auto": "Automatisch aus Callout-Titel generieren",
+              "manual": "Benutzerdefinierte URL festlegen"
             }
           },
           "title": {
@@ -392,7 +397,7 @@
         "title": "Sichtbarkeit"
       }
     },
-    "title": ""
+    "title": "Callout anlegen"
   },
   "footer": {
     "contactUs": "Kontaktieren Sie uns unter",
@@ -532,7 +537,7 @@
     "contribution": "Beitrag",
     "dashboard": "Dashboard",
     "home": "Home",
-    "legacyApp": "",
+    "legacyApp": "Alter Adminbereich",
     "logout": "Log out",
     "notices": "Hinweise",
     "settings": "Einstellungen",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -1,22 +1,27 @@
 {
   "adminDashboard": {
-    "joinSlack": "",
+    "hint1": "<p>Das beabee-Handbuch für Community-Journalismus [„Lust auf Lokal” ist erschienen](https://beabee.io/neu-handbuch-community-journalismus/). Es enthält nicht nur unser gesammeltes Wissen zum Aufbau unabhängiger Lokalredaktionen, sondern auch viele Beispiele aus der Praxis.</p>\n",
+    "hint2": "<p>Kennst du schon unseren [Kurs für die Reporterfabrik](https://beabee.io/online-kurs-fuer-community-journalismus/) von CORRECTIV? Dort lernst du Schritt für Schritt, wie Community-Journalismus funktioniert.</p>\n",
+    "hint3": "<p>Unsere Community-Meetups finden jeden dritten Donnerstag im Monat statt. Du willst dein Best-Practice-Beispiel mit anderen teilen? Schreib eine E-Mail an [tobias.hauswurz@correctiv.org](mailto:tobias.hauswurz@correctiv.org)</p>\n",
+    "joinSlack": "Tritt der beabee-Community auf Slack bei!",
     "latestCallout": {
-      "title": ""
+      "createNew": "",
+      "empty": "",
+      "title": "Letzer Callout"
     },
     "mostRecentMembers": {
-      "title": ""
+      "title": "Neueste Mitglieder"
     },
     "numbers": {
-      "averageContribution": "",
-      "newMembers": "",
-      "revenue": "",
-      "title": ""
+      "averageContribution": "Durchschn. monatlicher Beitrag",
+      "newMembers": "Neue Mitglieder",
+      "revenue": "Einnahmen",
+      "title": "Überblick der letzten 30 Tage"
     },
-    "responsesSoFar": "",
-    "seeAllResponses": "",
-    "supportInbox": "",
-    "welcomeBack": ""
+    "responsesSoFar": "Antworten bisher",
+    "seeAllResponses": "Alle Antworten anzeigen",
+    "supportInbox": "Benötigst du Hilfe? Schreib' uns eine E-Mail an:",
+    "welcomeBack": "Willkommen zurück {firstName}!"
   },
   "callout": {
     "contactDetails": "Kontaktdaten",
@@ -37,47 +42,47 @@
     "youResponded": "Du hast geantwortet ♥"
   },
   "calloutAdmin": {
-    "overview": "",
-    "responses": ""
+    "overview": "Überblick",
+    "responses": "Antworten"
   },
   "calloutAdminOverview": {
     "actions": {
-      "delete": "",
-      "edit": "",
-      "replicate": "",
-      "unpublish": "",
-      "view": ""
+      "delete": "Löschen",
+      "edit": "Bearbeiten",
+      "replicate": "Kopieren",
+      "unpublish": "Veröffentlichung aufheben",
+      "view": "Anzeigen"
     },
-    "created": "",
+    "created": "Gut gemacht! Dein Callout wurde erstellt.",
     "dates": {
-      "ends": "",
-      "label": "",
-      "starts": ""
+      "ends": "Ende",
+      "label": "Termine",
+      "starts": "Start"
     },
     "settings": {
       "answers": {
-        "editable": "",
-        "final": "",
-        "label": ""
+        "editable": "Können bearbeitet werden",
+        "final": "Können nicht bearbeitet werden",
+        "label": "Antworten"
       },
       "contactInfo": {
-        "label": "",
-        "optional": "",
-        "required": ""
+        "label": "Kontaktinformationen",
+        "optional": "Optional",
+        "required": "Benötigt"
       },
       "endsWith": {
-        "label": "",
-        "message": "",
-        "redirect": ""
+        "label": "Endet mit",
+        "message": "Dankesnachricht",
+        "redirect": "Weiterleitung"
       },
-      "label": "",
+      "label": "Einstellungen",
       "openTo": {
-        "everyone": "",
-        "label": "",
-        "membersOnly": ""
+        "everyone": "Alle",
+        "label": "Wer kann teilnehmen?",
+        "membersOnly": "Nur Mitglieder"
       }
     },
-    "summary": ""
+    "summary": "Zusammenfassung"
   },
   "callouts": {
     "archive": "Archiv",
@@ -232,10 +237,10 @@
   },
   "createCallout": {
     "actions": {
-      "back": "",
-      "continue": "",
-      "publish": "",
-      "schedule": ""
+      "back": "Zurück",
+      "continue": "Weiter",
+      "publish": "Veröffentlichen",
+      "schedule": "Planen"
     },
     "steps": {
       "content": {
@@ -298,8 +303,8 @@
         "title": "Nachricht am Ende"
       },
       "mailchimp": {
-        "description": "",
-        "title": ""
+        "description": "Mailchimp-Synchronisation einrichten",
+        "title": "Mailchimp-Synchronisation"
       },
       "titleAndImage": {
         "description": "Gib deinem Callout eine Titel, eine Beschreibung und ein Bild.",
@@ -331,18 +336,18 @@
             "placeholder": "Erkläre kurz und knapp, warum Menschen an dem Callout teilnehmen sollten."
           },
           "overrideShare": {
-            "label": "",
+            "label": "Callout-Titel und -Beschreibung zum Teilen verwenden?",
             "opts": {
-              "no": "",
-              "yes": ""
+              "no": "Nein, Titel und Beschreibung selbst festlegen",
+              "yes": "Ja"
             }
           },
           "slug": {
             "help": "<p>Die URL-Endung wird für die Webadresse des Callouts benötigt.</p>\n",
             "label": "URL-Endung",
             "opts": {
-              "auto": "",
-              "manual": ""
+              "auto": "Automatisch aus Callout-Titel generieren",
+              "manual": "Benutzerdefinierte URL festlegen"
             }
           },
           "title": {
@@ -392,7 +397,7 @@
         "title": "Sichtbarkeit"
       }
     },
-    "title": ""
+    "title": "Callout anlegen"
   },
   "footer": {
     "contactUs": "Kontaktiere uns unter",
@@ -532,7 +537,7 @@
     "contribution": "Beitrag",
     "dashboard": "Dashboard",
     "home": "Home",
-    "legacyApp": "",
+    "legacyApp": "Alter Adminbereich",
     "logout": "Log out",
     "notices": "Hinweise",
     "settings": "Einstellungen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,7 +1,12 @@
 {
   "adminDashboard": {
+    "hint1": "<p>Did you know callouts can be created without an end date, and just keep running? See our [feature showcase](https://beabee.io/en/beabee-full-feature-list/) for more information.</p>\n",
+    "hint2": "<p>Find out more about [the beabee vision](https://beabee.io/en/beabee-model/) around community engagement and meaningful relationships with your audience.</p>\n",
+    "hint3": "<p>Our [FAQ](https://beabee.io/en/beabee-faq/) addresses common questions about getting started and use cases. If the answer you're looking for isn't there, get in touch.</p>\n",
     "joinSlack": "Join the beabee community on Slack!",
     "latestCallout": {
+      "createNew": "Create a new one?",
+      "empty": "There are no active callouts.",
       "title": "Latest callout"
     },
     "mostRecentMembers": {

--- a/src/modules/admin/AdminPage.vue
+++ b/src/modules/admin/AdminPage.vue
@@ -45,14 +45,16 @@
       </div>
     </div>
     <div class="flex-1 basis-2/3">
-      <AppHeading>{{ t('adminDashboard.latestCallout.title') }}</AppHeading>
-      <p v-if="latestCallout" class="block bg-white p-4 mt-4 mb-8 rounded">
-        {{ t('adminDashboard.latestCallout.empty') }}
-        <router-link to="/admin/callouts/new" class="text-link">
-          {{ t('adminDashboard.latestCallout.createNew') }}
-        </router-link>
-      </p>
-      <CalloutSummary v-else-if="latestCallout === null" :callout="latestCallout" footer />
+      <div class="block bg-white p-4 mt-4 mb-8 rounded">
+        <AppHeading>{{ t('adminDashboard.latestCallout.title') }}</AppHeading>
+        <CalloutSummary v-if="latestCallout" :callout="latestCallout" footer />
+        <div v-else-if="latestCallout === null">
+          {{ t('adminDashboard.latestCallout.empty') }}
+          <router-link to="/admin/callouts/new" class="text-link">
+            {{ t('adminDashboard.latestCallout.createNew') }}
+          </router-link>
+        </div>
+      </div>
       <div
         class="
           p-10

--- a/src/modules/admin/AdminPage.vue
+++ b/src/modules/admin/AdminPage.vue
@@ -51,6 +51,15 @@
           <CalloutSummary :callout="latestCallout" footer />
         </a>
       </template>
+      <template v-else>
+        <AppHeading>{{ t('adminDashboard.latestCallout.title') }}</AppHeading>
+        <p class="block bg-white p-4 mt-4 mb-8 rounded">
+          No currently active callouts.
+          <router-link to="/admin/callouts/new" class="text-link">
+            Create a new one?
+          </router-link>
+        </p>
+      </template>
       <div
         class="
           p-10

--- a/src/modules/admin/AdminPage.vue
+++ b/src/modules/admin/AdminPage.vue
@@ -45,21 +45,14 @@
       </div>
     </div>
     <div class="flex-1 basis-2/3">
-      <template v-if="latestCallout">
-        <AppHeading>{{ t('adminDashboard.latestCallout.title') }}</AppHeading>
-        <a class="block bg-white p-4 mt-4 mb-8 rounded">
-          <CalloutSummary :callout="latestCallout" footer />
-        </a>
-      </template>
-      <template v-else>
-        <AppHeading>{{ t('adminDashboard.latestCallout.title') }}</AppHeading>
-        <p class="block bg-white p-4 mt-4 mb-8 rounded">
-          No currently active callouts.
-          <router-link to="/admin/callouts/new" class="text-link">
-            Create a new one?
-          </router-link>
-        </p>
-      </template>
+      <AppHeading>{{ t('adminDashboard.latestCallout.title') }}</AppHeading>
+      <p v-if="latestCallout" class="block bg-white p-4 mt-4 mb-8 rounded">
+        {{ t('adminDashboard.latestCallout.empty') }}
+        <router-link to="/admin/callouts/new" class="text-link">
+          {{ t('adminDashboard.latestCallout.createNew') }}
+        </router-link>
+      </p>
+      <CalloutSummary v-else-if="latestCallout === null" :callout="latestCallout" footer />
       <div
         class="
           p-10
@@ -150,7 +143,7 @@ const { n, t } = useI18n();
 
 const stats = ref<GetStatsData>();
 const recentMembers = ref<GetMemberData[]>([]);
-const latestCallout = ref<GetBasicCalloutData>();
+const latestCallout = ref<GetBasicCalloutData | null>();
 
 onBeforeMount(async () => {
   fetchStats({
@@ -169,9 +162,7 @@ onBeforeMount(async () => {
     sort: 'starts',
     order: 'DESC',
   }).then((results) => {
-    if (results.count > 0) {
-      latestCallout.value = results.items[0];
-    }
+    latestCallout.value = results.count > 0 ? results.items[0] : null;
   });
 });
 </script>


### PR DESCRIPTION
A first stab at the notice for when there's no active callout. The code presumes that `latestCallout` would be empty in the case there's no active callouts. Is this right?

(Not to be merged until we decide on a proper design for this element and implement it!)

Quick preview:

![image](https://user-images.githubusercontent.com/159868/163208734-62d7a2b9-12df-4a4a-a478-c52d4aa1dc2d.png)
