### PR TITLE
Hide share button on public view

### DIFF
--- a/src/modules/callouts/pages/CalloutPage.vue
+++ b/src/modules/callouts/pages/CalloutPage.vue
@@ -43,6 +43,7 @@
         v-if="callout.status === ItemStatus.Open"
         icon="share"
         variant="primaryOutlined"
+        class="hidden"
         >{{ t('common.share') }}</AppButton
       >
     </div>


### PR DESCRIPTION
https://trello.com/c/8LM2Ju48/491-%F0%9F%AA%B3-share-button-doesnt-do-anything-in-callouts