### PR TITLE
feat: add empty slot to AppTable, WIP contact list messages

### DIFF
--- a/src/components/table/AppTable.vue
+++ b/src/components/table/AppTable.vue
@@ -29,7 +29,7 @@
 
       <tr v-if="!items.length">
         <slot name="empty">
-          <p>Nothing here but crickets~</p>
+          <p>Loading contents, please wait...</p>
         </slot>
       </tr>
 

--- a/src/components/table/AppTable.vue
+++ b/src/components/table/AppTable.vue
@@ -26,6 +26,13 @@
     </thead>
 
     <tbody class="text-xs lg:text-sm">
+
+      <tr v-if="!items.length">
+        <slot name="empty">
+          <p>Nothing here but crickets~</p>
+        </slot>
+      </tr>
+
       <tr
         v-for="(item, i) in items"
         :key="i"

--- a/src/modules/callouts/CalloutsPage.vue
+++ b/src/modules/callouts/CalloutsPage.vue
@@ -25,57 +25,46 @@
       />
     </div>
   </div>
-  <table>
-    <thead class="text-left whitespace-nowrap hidden md:table-header-group">
-      <tr>
-        <th class="py-2">{{ t('callouts.data.callout') }}</th>
-        <th class="py-2 px-5">{{ t('callouts.data.endDate') }}</th>
-        <th class="py-2"></th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr
-        v-for="callout in archivedCallouts.items"
-        :key="callout.slug"
-        class="
-          flex flex-wrap
-          justify-between
-          py-3
-          md:table-row
-          border-t border-primary-20
-        "
+
+  <AppTable
+    v-model:sort="currentSort"
+    :headers="headers"
+    :items="archivedCallouts.items"
+    class="w-full mt-2 whitespace-nowrap"
+  >
+    <template #empty>
+      <p>{{ t('callout.noArchivedCallouts') }}</p>
+    </template>
+
+    <template #name="{ item }">
+      <router-link
+        :to="`/callouts/${item.slug}`"
+        class="text-base text-link font-bold"
+        >{{ item.title }}</router-link
       >
-        <td class="pb-2 md:py-4 w-full">
-          <router-link
-            :to="`/callouts/${callout.slug}`"
-            class="text-link font-semibold underline"
-            >{{ callout.title }}</router-link
-          >
-        </td>
-        <td class="md:py-4 md:px-5 whitespace-nowrap text-body-80 md:text-body">
-          <time
-            v-if="callout.expires"
-            :datetime="callout.expires.toISOString()"
-            :title="formatLocale(callout.expires, 'PPPppp')"
-          >
-            {{
-              t('common.timeAgo', {
-                time: formatDistanceLocale(new Date(), callout.expires),
-              })
-            }}
-          </time>
-          <span v-else>-</span>
-        </td>
-        <td
-          v-if="callout.hasAnswered"
-          class="md:py-4 text-success font-bold text-sm whitespace-nowrap"
-        >
-          <font-awesome-icon icon="check-circle" />
-          {{ t('callouts.showAnswered') }}
-        </td>
-      </tr>
-    </tbody>
-  </table>
+    </template>
+
+    <template #expires="{ item }">
+      <time
+        v-if="callout.expires"
+        :datetime="callout.expires.toISOString()"
+        :title="formatLocale(callout.expires, 'PPPppp')"
+      >
+        {{
+          t('common.timeAgo', {
+            time: formatDistanceLocale(new Date(), callout.expires),
+          })
+        }}
+      </time>
+      <span v-else>-</span>
+    </template>
+
+    <template #answered="{ item }" v-if"callout.hasAnswered">
+      <font-awesome-icon icon="check-circle" />
+      {{ t('callouts.showAnswered') }}
+    </template>
+  </AppTable>
+
   <div class="ml-auto mt-3">
     <AppPagination v-model="currentPage" :total-pages="totalPages" />
   </div>
@@ -125,7 +114,21 @@ const currentShow = computed({
       query: { ...route.query, show, page: undefined },
     }),
 });
-
+const currentSort = computed({
+  get: () => ({
+    by: (route.query.sortBy as string) || 'expires',
+    type: (route.query.sortType as SortType) || SortType.Desc,
+  }),
+  set: ({ by, type }) => {
+    router.replace({
+      query: {
+        ...route.query,
+        sortBy: by || undefined,
+        sortType: type,
+      },
+    });
+  },
+});
 const activeCallouts = ref<Paginated<GetBasicCalloutData>>({
   total: 0,
   count: 0,

--- a/src/modules/contacts/ContactsPage.vue
+++ b/src/modules/contacts/ContactsPage.vue
@@ -19,11 +19,8 @@
         :items="contactsTable.items"
         class="w-full mt-2 whitespace-nowrap"
       >
-        <template #empty v-if="route.query.s">
-          <p>{{ t('contacts.noResults') }}</p>
-        </template>
-        <template #empty v-else>
-          <p>{{ t('contacts.noContacts') }}</p>
+        <template #empty>
+          <p>{{ route.query.s ? t('contacts.noResults') : t('contacts.noContacts') }}</p>
         </template>
         <template #firstname="{ item }">
           <router-link

--- a/src/modules/contacts/ContactsPage.vue
+++ b/src/modules/contacts/ContactsPage.vue
@@ -19,6 +19,12 @@
         :items="contactsTable.items"
         class="w-full mt-2 whitespace-nowrap"
       >
+        <template #empty v-if="contactsTotal && contactsTotal.value">
+          <p>No results found.</p>
+        </template>
+        <template #empty v-else>
+          <p>No contacts added yet.</p>
+        </template>
         <template #firstname="{ item }">
           <router-link
             :to="'/admin/contacts/' + item.id"
@@ -67,7 +73,7 @@
               ><b>{{ n(contactsTable.total) }}</b></template
             >
           </i18n-t>
-          <i18n-t v-else keypath="contacts.noResults" />
+          <!-- <i18n-t v-else keypath="contacts.noResults" /> -->
         </p>
         <div class="mx-4">Page size</div>
 
@@ -241,5 +247,6 @@ watchEffect(async () => {
   if (!currentSegment.value) {
     contactsTotal.value = contactsTable.value.total;
   }
+
 });
 </script>

--- a/src/modules/contacts/ContactsPage.vue
+++ b/src/modules/contacts/ContactsPage.vue
@@ -20,10 +20,10 @@
         class="w-full mt-2 whitespace-nowrap"
       >
         <template #empty v-if="route.query.s">
-          <p>No results found.</p>
+          <p>{{ t('contacts.noResults') }}</p>
         </template>
         <template #empty v-else>
-          <p>No contacts added yet.</p>
+          <p>{{ t('contacts.noContacts') }}</p>
         </template>
         <template #firstname="{ item }">
           <router-link

--- a/src/modules/contacts/ContactsPage.vue
+++ b/src/modules/contacts/ContactsPage.vue
@@ -19,7 +19,7 @@
         :items="contactsTable.items"
         class="w-full mt-2 whitespace-nowrap"
       >
-        <template #empty v-if="contactsTotal && contactsTotal.value">
+        <template #empty v-if="route.query.s">
           <p>No results found.</p>
         </template>
         <template #empty v-else>

--- a/src/modules/contacts/ContactsPage.vue
+++ b/src/modules/contacts/ContactsPage.vue
@@ -70,7 +70,6 @@
               ><b>{{ n(contactsTable.total) }}</b></template
             >
           </i18n-t>
-          <!-- <i18n-t v-else keypath="contacts.noResults" /> -->
         </p>
         <div class="mx-4">Page size</div>
 

--- a/src/modules/contribution/components/PaymentsHistory.vue
+++ b/src/modules/contribution/components/PaymentsHistory.vue
@@ -10,6 +10,9 @@
       :hide-headers="true"
       class="w-full"
     >
+      <template #empty>
+        <p>{{ t('contribution.paymentHistory.empty') }}</p>
+      </template>
       <template #chargeDate="{ value }">
         {{ formatLocale(value, 'PPP') }}
       </template>


### PR DESCRIPTION
Very much work-in-progress ~~and not working yet~~, but I need some feedback on implementation details and a PR seems a good way to track those.

~~The main issue I need guidance with: when using search to filter the contact list, cases where there's no results should pop a specific empty message ("No results found"). We also want to accomodate a different empty message for when there's no contacts present at all.~~

~~However, I can't find a variable or state to make a condition against, to determine whether I'm running into an empty state because of a search with 0 results, or because there are no contacts at all. I just need that tidbit to be able to set a proper condition and take care of the other chores (e.g. mark strings as translatable)~~
 
~~(There already is a "no results found" message on the items count area, but it'd be preferable for it to appear in the table itself)~~

Decided to check whether a search query is present in the URL, it seems do to the trick.

