### PR TITLE
Additional info (er, ask for money) for non-members in callout

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -39,6 +39,8 @@
       "endsIn": "Ends in {duration}",
       "startsIn": "starts in {duration}"
     },
+    "toContributionPage": "Edit my contribution",
+    "updateContribution": "please update your contribution",
     "youResponded": "You replied to this callout ♥"
   },
   "calloutAdmin": {
@@ -195,6 +197,7 @@
       },
       "tags": "Tags"
     },
+    "noContacts": "No contacts added yet",
     "noResults": "No contacts found",
     "search": "Search contacts...",
     "showingOf": "Showing {start} to {end} contacts out of {total}"
@@ -217,6 +220,7 @@
     "paymentHistory": {
       "amount": "Amount",
       "date": "Date",
+      "empty": "Past payments and their invoices will show up here.",
       "title": "Payment history"
     },
     "paymentSourceUpdateError": "You can't update your bank account at the moment as you have a payment pending",

--- a/src/modules/callouts/pages/CalloutPage.vue
+++ b/src/modules/callouts/pages/CalloutPage.vue
@@ -64,11 +64,7 @@
     <figure class="relative mb-6 pb-[56.25%]">
       <img class="absolute w-full h-full object-cover" :src="callout.image" />
     </figure>
-    <div
-      class="text-lg content-message"
-      v-if="!canSeeButNotRespond"
-      v-html="callout.intro"
-    />
+    <div class="text-lg content-message" v-html="callout.intro" />
     <div
       class="
         w-full

--- a/src/modules/callouts/pages/CalloutPage.vue
+++ b/src/modules/callouts/pages/CalloutPage.vue
@@ -64,7 +64,33 @@
     <figure class="relative mb-6 pb-[56.25%]">
       <img class="absolute w-full h-full object-cover" :src="callout.image" />
     </figure>
-    <div class="text-lg content-message" v-html="callout.intro" />
+    <div
+      class="text-lg content-message"
+      v-if="!canSeeButNotRespond"
+      v-html="callout.intro"
+    />
+    <div
+      class="
+        w-full
+        text-lg text-center
+        flex flex-col
+        justify-center
+        items-center
+      "
+      v-if="canSeeButNotRespond"
+    >
+      <p class="w-full sm:w-2/3">
+        {{ t('callout.membersOnly') }}
+        <b>{{ t('callout.updateContribution') }}</b>
+      </p>
+      <AppButton
+        class="w-full sm:w-1/2 mt-4"
+        variant="link"
+        to="/profile/contribution"
+      >
+        {{ t('callout.toContributionPage') }}
+      </AppButton>
+    </div>
     <form
       v-if="showResponseForm"
       class="callout-form mt-10 pt-10 border-primary-40 border-t"
@@ -149,6 +175,15 @@ const canRespond = computed(
   () =>
     callout.value?.access !== 'member' ||
     currentUser.value?.activeRoles.includes('member')
+);
+
+// edge-case where a member is not contributing
+// (anymore) and should be given some indication as
+// to why they can't reply to a callout
+const canSeeButNotRespond = computed(
+  () =>
+    callout.value?.access === 'member' &&
+    !currentUser.value?.activeRoles.includes('member')
 );
 
 const showResponseForm = computed(

--- a/src/modules/callouts/pages/CalloutPage.vue
+++ b/src/modules/callouts/pages/CalloutPage.vue
@@ -177,12 +177,16 @@ const canRespond = computed(
     currentUser.value?.activeRoles.includes('member')
 );
 
-// edge-case where a member is not contributing
-// (anymore) and should be given some indication as
+// edge-case where a member is:
+// 1. logged in
+// 2. to a member-only callout
+// 3. but not contributing (anymore)
+// and should be given some indication as
 // to why they can't reply to a callout
 const canSeeButNotRespond = computed(
   () =>
     callout.value?.access === 'member' &&
+    currentUser.value &&
     !currentUser.value?.activeRoles.includes('member')
 );
 


### PR DESCRIPTION
[From this card](https://trello.com/c/c7I4SNk4/500-%F0%9F%AA%B3-show-message-if-a-logged-in-user-who-isnt-a-member-tries-to-access-a-member-only-callout): 

> At the moment if a logged in user who isn't a member (e.g. their membership expired) loads a member-only callout they just see the intro text without the form and no prompt.
We should add a prompt which says something like "You need to start a contribution to answer this callout" and point them to the contribution page

![image](https://user-images.githubusercontent.com/5701152/169067947-10bb544d-a193-40c5-8ac1-38b32b08cbe5.png)
