### PR TITLE
fix: top-aligned cell content, notes text size, tag paddings and margins

### DIFF
--- a/src/components/table/AppTable.vue
+++ b/src/components/table/AppTable.vue
@@ -40,7 +40,7 @@
         <td
           v-for="(header, j) in headers"
           :key="j"
-          class="p-2 align-bottom"
+          class="p-2 align-top"
           :align="header.align || undefined"
         >
           <slot :name="header.value" :item="item" :value="item[header.value]">{{

--- a/src/modules/contacts/ContactsPage.vue
+++ b/src/modules/contacts/ContactsPage.vue
@@ -33,7 +33,7 @@
           >
             {{ `${item.firstname} ${item.lastname}`.trim() || item.email }}
           </router-link>
-          <p v-if="item.profile.description" class="whitespace-normal mt-1">
+          <p v-if="item.profile.description" class="text-xs whitespace-normal mt-1">
             {{ item.profile.description }}
           </p>
         </template>

--- a/src/modules/contacts/components/ContactTag.vue
+++ b/src/modules/contacts/components/ContactTag.vue
@@ -7,9 +7,11 @@
       rounded
       font-bold
       inline-block
-      p-1
+      py-0.5
+      px-1
       mr-1
       mb-1
+      last-of-type:mb-0
       text-xs
       border border-white
     "


### PR DESCRIPTION
We edited the table component to make some design fixes (following the existing design spec):
- cell content aligns to the top (instead of bottom)
- notes, in contacts, are set in a smaller font size
- tags with adjusted padding and margin

All of the changes are tiny. The contacts table looks much tidier now :)