### PR TITLE
Refactor/normalise headers

### DIFF
--- a/src/components/AppSubHeading.vue
+++ b/src/components/AppSubHeading.vue
@@ -1,5 +1,5 @@
 <template>
-  <h2 class="font-title font-semibold text-xl text-body-80"><slot /></h2>
+  <h3 class="font-title font-semibold text-lg"><slot /></h3>
 </template>
 <script lang="ts" setup>
 /* Stub script for better type inference */

--- a/src/components/CalloutSummary.vue
+++ b/src/components/CalloutSummary.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="flex mb-4">
       <div class="flex-1">
-        <h3 class="font-semibold text-lg">{{ callout.title }}</h3>
+        <AppSubHeading>{{ callout.title }}</AppSubHeading>
         <p>{{ callout.excerpt }}</p>
       </div>
       <div class="flex-0 ml-4">
@@ -63,6 +63,7 @@ import {
   formatLocale,
   formatDistanceLocale,
 } from '../utils/dates/locale-date-formats';
+import AppSubHeading from './AppSubHeading.vue';
 
 const baseUrl = import.meta.env.VITE_APP_BASE_URL;
 const { t } = useI18n();

--- a/src/components/SectionTitle.vue
+++ b/src/components/SectionTitle.vue
@@ -1,5 +1,0 @@
-<template>
-  <h2 class="font-title text-lg font-bold">
-    <slot />
-  </h2>
-</template>

--- a/src/components/welcome-message/WelcomeMessage.vue
+++ b/src/components/welcome-message/WelcomeMessage.vue
@@ -15,17 +15,17 @@
     <div class="flex items-center md:items-start mb-2 md:mb-0">
       <WelcomeIcon class="icon md:hidden lg:block" />
 
-      <h3 class="title md:hidden ml-4">
-        {{ t('homePage.welcome', { firstName: memberFirstName }) }}
-      </h3>
+      <AppSubHeading class="md:hidden ml-4">
+        {{ t('homePage.welcome', { firstName }) }}
+      </AppSubHeading>
     </div>
 
     <div class="lg:ml-8 flex-grow">
       <WelcomeIcon class="hidden md:block lg:hidden icon float-left mr-4" />
 
-      <h3 class="title mb-3 hidden md:block">
-        {{ t('homePage.welcome', { firstName: memberFirstName }) }}
-      </h3>
+      <AppSubHeading class="mb-3 hidden md:block">
+        {{ t('homePage.welcome', { firstName }) }}
+      </AppSubHeading>
 
       <div
         class="
@@ -52,6 +52,7 @@
 <script lang="ts" setup>
 import WelcomeIcon from './WelcomeIcon.vue';
 import { useI18n } from 'vue-i18n';
+import AppSubHeading from '../AppSubHeading.vue';
 
 const { t } = useI18n();
 
@@ -70,10 +71,6 @@ defineEmits(['close']);
 </script>
 
 <style scoped>
-.title {
-  @apply text-lg font-semibold;
-}
-
 .icon {
   width: 4.5rem;
   height: 5rem;

--- a/src/modules/auth/join/JoinPage.vue
+++ b/src/modules/auth/join/JoinPage.vue
@@ -7,12 +7,9 @@
         :description="joinContent.subtitle"
       />
 
-      <h3
-        v-if="joinContent.showNoContribution"
-        class="font-semibold text-lg mb-1"
-      >
+      <AppSubHeading v-if="joinContent.showNoContribution" class="mb-1">
         {{ t('join.contribution') }}
-      </h3>
+      </AppSubHeading>
 
       <div v-if="joinContent.showNoContribution" class="mb-4">
         <label>
@@ -75,6 +72,7 @@ import { fetchContent } from '../../../utils/api/content';
 import { ContributionPeriod } from '../../../utils/enums/contribution-period.enum';
 import { signUp } from '../../../utils/api/signup';
 import useVuelidate from '@vuelidate/core';
+import AppSubHeading from '../../../components/AppSubHeading.vue';
 
 const { t, n } = useI18n();
 

--- a/src/modules/auth/join/components/AccountSection.vue
+++ b/src/modules/auth/join/components/AccountSection.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="mb-6">
-    <h3 class="font-semibold text-lg mb-1">{{ t('join.memberAccount') }}</h3>
+    <AppSubHeading class="mb-1">{{ t('join.memberAccount') }}</AppSubHeading>
 
     <p class="mb-3 text-sm">
       {{ t('join.memberAlready') }}
@@ -42,6 +42,7 @@ import {
   passwordValidationRule,
 } from '../../../../utils/form-validation/rules';
 import { computed } from 'vue';
+import AppSubHeading from '../../../../components/AppSubHeading.vue';
 
 const emit = defineEmits(['update:email', 'update:password']);
 const props = defineProps<{

--- a/src/modules/contribution/ContributionPage.vue
+++ b/src/modules/contribution/ContributionPage.vue
@@ -13,9 +13,7 @@
       <ContributionBox :contribution="currentContribution" class="mb-9" />
 
       <form class="mb-7 md:mb-12" @submit.prevent="submitContribution">
-        <SectionTitle class="mb-2"
-          >{{ t('contribution.billing') }}
-        </SectionTitle>
+        <AppHeading class="mb-2">{{ t('contribution.billing') }} </AppHeading>
 
         <p v-if="hasManualType" class="mb-4">
           {{ t('contribution.manualPayment') }}
@@ -63,9 +61,9 @@
       </form>
 
       <template v-if="currentContribution.paymentSource">
-        <SectionTitle class="mb-4">{{
+        <AppHeading class="mb-4">{{
           t('contribution.bankAccount')
-        }}</SectionTitle>
+        }}</AppHeading>
 
         <PaymentSource
           class="mb-7 md:mb-12"
@@ -77,9 +75,9 @@
       </template>
 
       <template v-if="isActiveMemberWithGoCardless">
-        <SectionTitle class="mb-4">{{
+        <AppHeading class="mb-4">{{
           t('contribution.cancelContribution')
-        }}</SectionTitle>
+        }}</AppHeading>
 
         <CancelContribution
           class="mb-9 md:mb-0"
@@ -110,13 +108,13 @@ import PaymentSource from './components/PaymentSource.vue';
 
 import PageTitle from '../../components/PageTitle.vue';
 import InfoMessage from '../../components/InfoMessage.vue';
-import SectionTitle from '../../components/SectionTitle.vue';
 import Contribution from '../../components/contribution/Contribution.vue';
 import AppButton from '../../components/forms/AppButton.vue';
 import ProrateContribution from './components/ProrateContribution.vue';
 import AppAlert from '../../components/AppAlert.vue';
 import MessageBox from '../../components/MessageBox.vue';
 import PaymentsHistory from './components/PaymentsHistory.vue';
+import AppHeading from '../../components/AppHeading.vue';
 
 const { t } = useI18n();
 

--- a/src/modules/contribution/components/ContributionBox.vue
+++ b/src/modules/contribution/components/ContributionBox.vue
@@ -4,7 +4,9 @@
     class="flex flex-col p-8 bg-white shadow"
   >
     <template v-if="contribution.membershipStatus === MembershipStatus.Expired">
-      <p class="text-lg mb-2 font-semibold">{{ t('contribution.expired') }}</p>
+      <AppSubHeading class="mb-2">{{
+        t('contribution.expired')
+      }}</AppSubHeading>
 
       <p>
         {{ t('contribution.expiredText') }}
@@ -70,6 +72,7 @@ import { ContributionPeriod } from '../../../utils/enums/contribution-period.enu
 import { ContributionInfo } from '../../../utils/api/api.interface';
 import { MembershipStatus } from '../../../utils/enums/membership-status.enum';
 import { ContributionType } from '../../../utils/enums/contribution-type.enum';
+import AppSubHeading from '../../../components/AppSubHeading.vue';
 
 const { n, t } = useI18n();
 

--- a/src/modules/contribution/components/PaymentsHistory.vue
+++ b/src/modules/contribution/components/PaymentsHistory.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-if="paymentsHistoryTable.total > 0">
-    <SectionTitle class="mb-2">{{
+    <AppHeading class="mb-2">{{
       t('contribution.paymentHistory.title')
-    }}</SectionTitle>
+    }}</AppHeading>
     <AppTable
       :sort="{ by: 'chargeDate', type: SortType.Desc }"
       :headers="headers"
@@ -35,7 +35,6 @@ import { useI18n } from 'vue-i18n';
 import { computed, ref, watchEffect } from 'vue';
 
 import AppTable from '../../../components/table/AppTable.vue';
-import SectionTitle from '../../../components/SectionTitle.vue';
 import AppPagination from '../../../components/AppPagination.vue';
 import { formatLocale } from '../../../utils/dates/locale-date-formats';
 
@@ -43,6 +42,7 @@ import { fetchPayments } from '../../../utils/api/member';
 import { Paginated } from '../../../utils/api/api.interface';
 import { GetPaymentData } from '../../../utils/api/api.interface';
 import { Header, SortType } from '../../../components/table/table.interface';
+import AppHeading from '../../../components/AppHeading.vue';
 
 const { t, n } = useI18n();
 

--- a/src/modules/home/HomePage.vue
+++ b/src/modules/home/HomePage.vue
@@ -28,12 +28,7 @@
   </section>
 
   <section v-if="callouts.length" class="mb-6 lg:mr-6">
-    <SectionTitle class="mb-6 md:hidden">{{
-      t('homePage.openCallouts')
-    }}</SectionTitle>
-    <AppHeading class="mb-2 hidden md:block">{{
-      t('homePage.openCallouts')
-    }}</AppHeading>
+    <SectionTitle>{{ t('homePage.openCallouts') }}</SectionTitle>
 
     <div class="flex -mx-3 my-6 flex-wrap">
       <CalloutCard
@@ -50,12 +45,7 @@
   </section>
 
   <section>
-    <SectionTitle class="mb-6 md:hidden">{{
-      t('homePage.yourProfile')
-    }}</SectionTitle>
-    <AppHeading class="mb-2 hidden md:block">{{
-      t('homePage.yourProfile')
-    }}</AppHeading>
+    <SectionTitle>{{ t('homePage.yourProfile') }}</SectionTitle>
 
     <div class="flex mb-4">
       <ContributionInfo :member="user" />
@@ -88,7 +78,6 @@ import AppButton from '../../components/forms/AppButton.vue';
 import AppAlert from '../../components/AppAlert.vue';
 import CalloutCard from '../../components/CalloutCard.vue';
 import WelcomeMessage from '../../components/welcome-message/WelcomeMessage.vue';
-import AppHeading from '../../components/AppHeading.vue';
 import {
   GetBasicCalloutData,
   GetMemberData,

--- a/src/modules/home/components/QuickActions.vue
+++ b/src/modules/home/components/QuickActions.vue
@@ -1,7 +1,5 @@
 <template>
-  <SectionTitle class="uppercase">{{
-    t('homePage.quickActions')
-  }}</SectionTitle>
+  <SectionTitle>{{ t('homePage.quickActions') }}</SectionTitle>
 
   <ul class="list-disc pl-4 font-semibold underline space-y-2 mt-4">
     <!--<li>

--- a/src/modules/home/components/SectionTitle.vue
+++ b/src/modules/home/components/SectionTitle.vue
@@ -1,17 +1,15 @@
 <template>
-  <div class="flex h-8 items-center">
-    <span class="heading-decoration" />
+  <div class="flex h-8 items-center mb-6 md:hidden">
+    <span class="h-px flex-grow bg-primary-20" />
     <h2
       class="text-sm text-primary-40 font-semibold uppercase text-center px-3"
     >
       <slot />
     </h2>
-    <span class="heading-decoration" />
+    <span class="h-px flex-grow bg-primary-20" />
   </div>
+  <AppHeading class="mb-2 hidden md:block"><slot /></AppHeading>
 </template>
-
-<style scoped>
-.heading-decoration {
-  @apply h-px flex-grow bg-primary-20;
-}
-</style>
+<script lang="ts" setup>
+import AppHeading from '../../../components/AppHeading.vue';
+</script>


### PR DESCRIPTION
We have a lot of different header styles creeping in, this is an attempt to rationalise it a bit.

I've merged `SectionTitle` into `AppSubHeading` as they were both being used for the same thing in different places (e.g. your information vs contribution page). I've used `font-semibold` over `font-bold` (the only difference between the two), but happy to go with `font-bold` if you prefer.

We now have:
* `PageTitle`: `font-title text-2.5xl`
* `AppHeading`: `font-title text-xl font-semibold text-body-80`
* `AppSubHeading`: `font-title text-lg font-semibold`

The home page has it's own `SectionTitle` (another one!) which I've cleaned up a bit for consistency but otherwise left it as is for now.

There are probably lots of other places where there are inconsistencies but this is a good start I think