### PR TITLE
feat: show name fields on payment form

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -553,7 +553,6 @@
     "privacy": "Datenschutzerklärung"
   },
   "joinPayment": {
-    "complete": "Zahlung abschließen",
     "genericError": "Upps! Etwas ist schiefgelaufen. Bitte wenden Sie sich an den Support, sollte das erneut passieren.",
     "goBack": "Möchten Sie etwas ändern? {back}",
     "goBackButton": "Zurück zum letzten Schritt",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -553,7 +553,6 @@
     "privacy": "Datenschutzerklärung"
   },
   "joinPayment": {
-    "complete": "Zahlung abschließen",
     "genericError": "Upps! Etwas ist schiefgelaufen. Bitte wende dich an den Support, sollte das erneut passieren.",
     "goBack": "Möchtest du etwas ändern? {back}",
     "goBackButton": "Zurück zum letzten Schritt",

--- a/locales/en.json
+++ b/locales/en.json
@@ -553,7 +553,6 @@
     "privacy": "Privacy Policy"
   },
   "joinPayment": {
-    "complete": "Complete",
     "genericError": "Oops, something went wrong! Contact support if this happens again.",
     "goBack": "Did you miss something? {back}",
     "goBackButton": "Back to the previous screen",

--- a/plugins/theme.ts
+++ b/plugins/theme.ts
@@ -21,6 +21,7 @@ export default function themePlugin(): Plugin {
           JSON.stringify({
             colors: fullConfig.theme.colors,
             fontFamily: fullConfig.theme.fontFamily,
+            fontSize: fullConfig.theme.fontSize,
             borderRadius: fullConfig.theme.borderRadius,
             boxShadow: fullConfig.theme.boxShadow,
             spacing: fullConfig.theme.spacing,

--- a/src/components/StripePayment.vue
+++ b/src/components/StripePayment.vue
@@ -30,7 +30,7 @@
     type="submit"
     class="w-full mt-4"
     @click="completePayment"
-    >{{ t('joinPayment.complete') }}</AppButton
+    >{{ t('actions.continue') }}</AppButton
   >
 </template>
 <script lang="ts" setup>

--- a/src/modules/auth/join/JoinPage.vue
+++ b/src/modules/auth/join/JoinPage.vue
@@ -80,6 +80,7 @@
         :client-secret="stripeClientSecret"
         :email="signUpData.email"
         :return-url="completeUrl"
+        show-name-fields
         @loaded="
           stripePaymentLoaded = true;
           loading = false;

--- a/src/modules/auth/join/pages/CompletePage.vue
+++ b/src/modules/auth/join/pages/CompletePage.vue
@@ -15,7 +15,11 @@ onBeforeMount(async () => {
 
   if (paymentFlowId) {
     try {
-      await completeSignUp(paymentFlowId);
+      await completeSignUp({
+        paymentFlowId,
+        firstname: route.query.firstName?.toString(),
+        lastname: route.query.lastName?.toString(),
+      });
       router.replace('/join/confirm-email');
       return;
     } catch (err) {}

--- a/src/utils/api/api.interface.ts
+++ b/src/utils/api/api.interface.ts
@@ -338,6 +338,12 @@ export interface SignupData extends StartContributionData {
   noContribution: boolean;
 }
 
+export interface CompleteSignupData {
+  paymentFlowId: string;
+  firstname?: string;
+  lastname?: string;
+}
+
 export interface GetSegmentData {
   id: string;
   name: string;

--- a/src/utils/api/signup.ts
+++ b/src/utils/api/signup.ts
@@ -1,6 +1,11 @@
 import axios from '../../axios';
 import { ContributionPeriod } from '../enums/contribution-period.enum';
-import { PaymentFlowParams, Serial, SignupData } from './api.interface';
+import {
+  CompleteSignupData,
+  PaymentFlowParams,
+  Serial,
+  SignupData,
+} from './api.interface';
 
 export const completeUrl = import.meta.env.VITE_APP_BASE_URL + '/join/complete';
 
@@ -26,8 +31,12 @@ export async function signUp(data: SignupData): Promise<PaymentFlowParams> {
   ).data;
 }
 
-export async function completeSignUp(paymentFlowId: string): Promise<void> {
-  await axios.post('/signup/complete', { paymentFlowId });
+export async function completeSignUp(data: CompleteSignupData): Promise<void> {
+  await axios.post('/signup/complete', {
+    paymentFlowId: data.paymentFlowId,
+    firstname: data.firstname,
+    lastname: data.lastname,
+  });
 }
 
 export async function confirmEmail(


### PR DESCRIPTION
Adds first and last name fields to the Stripe payment form. beabee needs this information to be collected separately (Stripe collects it as a full name field) so we can do things like send emails that say "Hi Will"

Note: at the moment there is a slight visual difference between the first/last name fields and the Stripe payment fields because we aren't yet syncing font families into the Stripe iframe. This will be addressed in a future PR

![image](https://user-images.githubusercontent.com/2084823/176422135-d092662d-ad9a-4531-b24b-db5e2e90ea40.png)
