### PR TITLE
fix: removed callout image height constrain

### DIFF
--- a/src/modules/callouts/pages/CalloutPage.vue
+++ b/src/modules/callouts/pages/CalloutPage.vue
@@ -72,14 +72,7 @@
     </figure>
     <div class="text-lg content-message mb-6" v-html="callout.intro" />
     <div
-      class="
-        w-full
-        text-center
-        flex flex-col
-        justify-center
-        items-center
-        mb-6
-      "
+      class="w-full text-center flex flex-col justify-center items-center mb-6"
       v-if="canSeeButNotRespond"
     >
       <p class="w-full sm:w-2/3">

--- a/src/modules/callouts/pages/CalloutPage.vue
+++ b/src/modules/callouts/pages/CalloutPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="callout" class="md:max-w-2xl">
-    <h1 class="font-title text-4xl font-bold mb-8">{{ callout.title }}</h1>
-    <div class="flex justify-between items-center mb-8">
+    <h1 class="font-title text-4xl font-bold mb-6">{{ callout.title }}</h1>
+    <div class="flex justify-between items-center mb-6">
       <div class="flex items-center text-sm text-body-40 font-semibold">
         <div>
           <div class="flex flex-col">
@@ -67,17 +67,18 @@
         />
       </div>
     </div>
-    <figure class="relative mb-6 pb-[56.25%]">
-      <img class="absolute w-full h-full object-cover" :src="callout.image" />
+    <figure class="mb-6">
+      <img class="w-full object-cover" :src="callout.image" />
     </figure>
-    <div class="text-lg content-message" v-html="callout.intro" />
+    <div class="text-lg content-message mb-6" v-html="callout.intro" />
     <div
       class="
         w-full
-        text-lg text-center
+        text-center
         flex flex-col
         justify-center
         items-center
+        mb-6
       "
       v-if="canSeeButNotRespond"
     >


### PR DESCRIPTION
In the callout page, the main image had a fixed ratio which resulted in an undesirable crop of the original image.
This is a small fix: the image takes the full width but has variable height.

A callout with a _portrait_ image:
![image](https://user-images.githubusercontent.com/122730/178765388-59b7abd3-2fcf-4f48-8c0f-14fed0c7771a.png)

A callout with a _landscape_ image:
![image](https://user-images.githubusercontent.com/122730/178765530-8d359f16-f138-4a16-aa43-815b3d8ddb85.png)
