### PR TITLE
Better CSS syntax highlighting

### DIFF
--- a/src/components/AppInfoList.vue
+++ b/src/components/AppInfoList.vue
@@ -1,11 +1,13 @@
 <template>
-  <dl class="grid gap-x-2 gap-y-1 items-baseline mt-2">
+  <dl
+    class="
+      grid
+      gap-x-2 gap-y-1
+      items-baseline
+      mt-2
+      grid-cols-[minmax(100px,200px)_1fr]
+    "
+  >
     <slot />
   </dl>
 </template>
-
-<style scoped>
-dl {
-  grid-template-columns: minmax(100px, 200px) 1fr;
-}
-</style>

--- a/src/components/AuthBox.vue
+++ b/src/components/AuthBox.vue
@@ -9,7 +9,8 @@
         md:px-8
         mx-auto
         rounded-md
-        auth-box
+        shadow-auth-box
+        max-w-[30rem]
         mb-3
       "
     >
@@ -17,10 +18,3 @@
     </div>
   </div>
 </template>
-
-<style scoped>
-.auth-box {
-  box-shadow: 0 0 1rem 0.125rem rgba(51, 51, 51, 0.4);
-  max-width: 30rem;
-}
-</style>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -80,7 +80,7 @@ const { t } = useI18n();
 </script>
 
 /* TODO: fix relying on scoped */
-<style scoped>
+<style lang="postcss" scoped>
 a {
   @apply text-link;
 }

--- a/src/components/contribution/ContributionAmount.vue
+++ b/src/components/contribution/ContributionAmount.vue
@@ -189,7 +189,7 @@ const period = computed(() => {
 });
 </script>
 
-<style scoped>
+<style lang="postcss" scoped>
 .amount-button {
   @apply h-1/2 bg-white py-2 px-4 text-primary-70 hover:text-link border-primary-40;
   &.is-invalid {

--- a/src/components/forms/AppColorInput.vue
+++ b/src/components/forms/AppColorInput.vue
@@ -55,7 +55,7 @@ watch(
 );
 </script>
 
-<style>
+<style lang="postcss">
 /* This needs more specificity to apply on production builds */
 .vacp-color-picker.vacp-color-picker {
   padding: 0;

--- a/src/components/notification/NotificationContainer.vue
+++ b/src/components/notification/NotificationContainer.vue
@@ -38,7 +38,7 @@ onBeforeMount(() => {
 });
 </script>
 
-<style scoped>
+<style lang="postcss" scoped>
 .fade-leave-active {
   @apply transition ease-linear duration-200;
 }

--- a/src/components/pages/callouts/steps/Content.vue
+++ b/src/components/pages/callouts/steps/Content.vue
@@ -130,7 +130,7 @@ onBeforeMount(() => {
   dom.watch();
 });
 </script>
-<style>
+<style lang="postcss">
 .callout-form-builder {
   .drag-and-drop-alert {
     @apply p-4 border border-dashed border-primary mb-4;

--- a/src/components/pages/profile/ContributionInfo.vue
+++ b/src/components/pages/profile/ContributionInfo.vue
@@ -48,7 +48,7 @@ const formattedJoinedDate = computed(() => {
 });
 </script>
 
-<style scoped>
+<style lang="postcss" scoped>
 .title {
   @apply text-sm text-primary-80 font-semibold -mt-3 mb-3;
 }

--- a/src/components/rte/RichTextEditor.vue
+++ b/src/components/rte/RichTextEditor.vue
@@ -164,7 +164,7 @@ function setLink() {
 }
 </script>
 
-<style>
+<style lang="postcss">
 .ProseMirror {
   @apply p-2 min-h-[5rem] h-auto bg-white w-full border border-primary-40 rounded focus:outline-none focus:shadow-input;
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -56,6 +56,7 @@ module.exports = {
       boxShadow: {
         DEFAULT: '0 0 8px 0 rgba(0, 0, 0, 0.2)',
         input: 'var(--bs-input)',
+        'auth-box': '0 0 1rem 0.125rem rgba(51, 51, 51, 0.4)',
       },
       fontSize: {
         '2.5xl': '1.75rem',


### PR DESCRIPTION
This PR is purely to improve the syntax highlighting in IDEs like VS Code. By tagging the CSS as postcss it adds support for things like nesting and `@apply` rules

I also removed a few unnecessary `<style>` tags as per the Tailwind way.