### PR TITLE
Manual contribution related API changes

### DIFF
--- a/src/components/pages/profile/contribution/PaymentSource.vue
+++ b/src/components/pages/profile/contribution/PaymentSource.vue
@@ -43,7 +43,10 @@ import { onBeforeMount, ref } from 'vue';
 import MessageBox from '../../../MessageBox.vue';
 import AppButton from '../../../forms/AppButton.vue';
 import { useI18n } from 'vue-i18n';
-import { PaymentSource } from '../../../../utils/api/api.interface';
+import {
+  ManualPaymentSource,
+  PaymentSource,
+} from '../../../../utils/api/api.interface';
 import {
   updatePaymentMethod,
   updatePaymentMethodCompleteUrl,
@@ -60,7 +63,7 @@ const { t } = useI18n();
 
 const props = defineProps<{
   stripePublicKey: string;
-  paymentSource: PaymentSource;
+  paymentSource: Exclude<PaymentSource, ManualPaymentSource>;
   email: string;
 }>();
 

--- a/src/pages/profile/contribution/index.vue
+++ b/src/pages/profile/contribution/index.vue
@@ -25,7 +25,7 @@ meta:
       />
 
       <PaymentSource
-        v-if="contribution.paymentSource"
+        v-if="contribution.paymentSource?.method"
         class="mb-7 md:mb-9"
         :email="email"
         :payment-source="contribution.paymentSource"

--- a/src/utils/api/api.interface.ts
+++ b/src/utils/api/api.interface.ts
@@ -125,18 +125,18 @@ export interface UpdateMemberData extends Partial<MemberData> {
   profile?: UpdateMemberProfileData;
 }
 
-export interface CardPaymentSource {
-  method: PaymentMethod.StripeCard;
-  last4: string;
-  expiryMonth: number;
-  expiryYear: number;
-}
-
 export interface GoCardlessDirectDebitPaymentSource {
   method: PaymentMethod.GoCardlessDirectDebit;
   bankName: string;
   accountHolderName: string;
   accountNumberEnding: string;
+}
+
+export interface StripeCardPaymentSource {
+  method: PaymentMethod.StripeCard;
+  last4: string;
+  expiryMonth: number;
+  expiryYear: number;
 }
 
 export interface StripeBACSPaymentSource {
@@ -153,11 +153,18 @@ export interface StripeSEPAPaymentSource {
   last4: string;
 }
 
+export interface ManualPaymentSource {
+  method: null;
+  source?: string;
+  reference?: string;
+}
+
 export type PaymentSource =
-  | CardPaymentSource
+  | StripeCardPaymentSource
   | GoCardlessDirectDebitPaymentSource
   | StripeBACSPaymentSource
-  | StripeSEPAPaymentSource;
+  | StripeSEPAPaymentSource
+  | ManualPaymentSource;
 
 export interface ContributionInfo {
   type: ContributionType;

--- a/src/utils/api/api.interface.ts
+++ b/src/utils/api/api.interface.ts
@@ -180,6 +180,14 @@ export interface SetContributionData {
   period: ContributionPeriod;
 }
 
+export interface ForceUpdateContributionData {
+  type: ContributionType.Manual | ContributionType.None;
+  amount: number | null;
+  period: ContributionPeriod | null;
+  source?: string;
+  reference?: string;
+}
+
 export interface StartContributionData extends SetContributionData {
   paymentMethod: PaymentMethod;
 }

--- a/src/utils/api/member.ts
+++ b/src/utils/api/member.ts
@@ -4,6 +4,7 @@ import { ContributionPeriod } from '../../utils/enums/contribution-period.enum';
 import { PaymentMethod } from '../enums/payment-method.enum';
 import {
   ContributionInfo,
+  ForceUpdateContributionData,
   GetMemberData,
   GetMemberDataWith,
   GetMembersQuery,
@@ -115,6 +116,23 @@ export async function updateContribution(
       amount: dataIn.amount,
       payFee: dataIn.payFee && dataIn.period === ContributionPeriod.Monthly,
       prorate: dataIn.prorate && dataIn.period === ContributionPeriod.Annually,
+    }
+  );
+  return deserializeContribution(data);
+}
+
+export async function forceUpdateContribution(
+  id: string,
+  dataIn: ForceUpdateContributionData
+): Promise<ContributionInfo> {
+  const { data } = await axios.patch<Serial<ContributionInfo>>(
+    `/member/${id}/contribution/force`,
+    {
+      type: dataIn.type,
+      amount: dataIn.amount,
+      period: dataIn.period,
+      source: dataIn.source,
+      reference: dataIn.reference,
     }
   );
   return deserializeContribution(data);


### PR DESCRIPTION
This PR adds the changes introduced in https://github.com/beabee-communityrm/beabee/pull/193.

* `ContributionInfo` can now return a `paymentSource` for manual contributions that has a `source` and `reference`
* Added `forceUpdateContribution` endpoint to update manual contributions