### PR TITLE
Improve i18n script to reduce changes from other branches and unused locales

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "vue-tsc --noEmit && vite build",
     "serve": "vite preview",
     "prepare": "husky install",
-    "i18n": "node scripts/i18n"
+    "i18n": "node scripts/i18n $(git rev-parse --symbolic-full-name --abbrev-ref HEAD)"
   },
   "dependencies": {
     "@fontsource/fira-sans": "^4.5.9",

--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -1,5 +1,13 @@
-/* eslint-disable no-console */
-/* eslint-disable @typescript-eslint/no-var-requires */
+/**
+ * Script to load locale data from a Google sheet
+ *
+ * Run: ./i18n.js [sheet name]
+ *
+ * Column headers should be locale codes, codes that start with an exclamation mark (!) are ignored.
+ *
+ * The script can optional load a second sheet to overwrite the main sheet, we add a new sheet for a
+ * branch so changes for different features are kept separate.
+ */
 const fs = require('fs');
 const path = require('path');
 const { google } = require('googleapis');
@@ -10,6 +18,15 @@ const simpleMd = new MarkdownIt('zero').enable(['emphasis', 'link']);
 const optHandlers = {
   md: (data) => simpleMd.render(data),
 };
+
+const auth = new google.auth.GoogleAuth({
+  keyFile: path.join(__dirname, '.credentials.json'),
+  scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
+});
+
+const sheets = google.sheets({ version: 'v4', auth });
+
+const localeData = {};
 
 function processKeyData(keyOpts, keyData) {
   if (keyData !== undefined) {
@@ -23,17 +40,12 @@ function processKeyData(keyOpts, keyData) {
   }
 }
 
-const auth = new google.auth.GoogleAuth({
-  keyFile: path.join(__dirname, '.credentials.json'),
-  scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
-});
+async function loadSheet(name) {
+  console.log('Loading sheet ' + name);
 
-const sheets = google.sheets({ version: 'v4', auth });
-
-(async () => {
   const resp = await sheets.spreadsheets.values.get({
     spreadsheetId: '1l35DW5OMi-xM8HXek5Q1jOxsXScINqqpEvPWDlpBPX8',
-    range: 'Sheet1',
+    range: name,
   });
 
   const headers = resp.data.values[0];
@@ -46,8 +58,13 @@ const sheets = google.sheets({ version: 'v4', auth });
     // Sort by key for predictable output
     .sort((a, b) => (a.key < b.key ? -1 : 1));
 
-  const locales = headers.filter((h) => h !== 'key');
-  const localeData = Object.fromEntries(locales.map((locale) => [locale, {}]));
+  // Add locales to data
+  const locales = headers.filter((h) => h !== 'key' && !h.startsWith('!'));
+  for (const locale of locales) {
+    if (!localeData[locale]) {
+      localeData[locale] = {};
+    }
+  }
 
   // Construct nested objects from a.b.c key paths
   for (const row of rows) {
@@ -68,8 +85,18 @@ const sheets = google.sheets({ version: 'v4', auth });
       localeDataPart[lastKeyPart] = processKeyData(keyOpts, row[locale]);
     }
   }
+}
 
-  for (const locale of locales) {
+(async () => {
+  await loadSheet('Sheet1');
+
+  if (process.argv[2] && process.argv[2] !== 'main') {
+    try {
+      await loadSheet(process.argv[2]);
+    } catch {}
+  }
+
+  for (const locale in localeData) {
     console.log('Updating ' + locale);
     fs.writeFileSync(
       path.join(__dirname, '../locales', locale + '.json'),


### PR DESCRIPTION
This PR solves two problems with our i18n workflow:
* At the moment we use one main sheet for all our translations. In practice this means:
  * People working on different branches end up pulling in each others new translations when they use the update script
  * The main translations can go out of sync with the `main` branch
* We have some inactive locales which give pointless updates or generate untracked files
 
Now you can:
* Mark a locale as inactive by preceding it with an exclamation mark.
* Create a new sheet with the same name as your branch for new translations or changes. Use the helper script `npm run i18n`, it automatically tries to fetch these changes