### PR TITLE
chore: remove non-main advanced search translations

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -102,71 +102,6 @@
     },
     "title": "Einstellungen"
   },
-  "advancedSearch": {
-    "addRule": "Filter hinzufügen",
-    "button": "Erweiterte Suche",
-    "createFilters": "Filter für die Suche erstellen",
-    "matchAfter": "der folgenden Filter enthalten",
-    "matchBefore": "Ergebnisse sollen",
-    "matchType": {
-      "all": "alle",
-      "any": "mindestens einen"
-    },
-    "matchWord": {
-      "all": "und",
-      "any": "oder"
-    },
-    "operators": {
-      "all": {
-        "is_empty": "ist leer",
-        "is_not_empty": "ist nicht leer"
-      },
-      "array": {
-        "contains": "enthält",
-        "not_contains": "enthält nicht"
-      },
-      "boolean": {
-        "equal": "ist"
-      },
-      "date": {
-        "between": "zwischen",
-        "equal": "ist",
-        "greater": "nach",
-        "greater_or_equal": "nach oder am",
-        "less": "vor",
-        "less_or_equal": "vor oder am",
-        "not_between": "nicht zwischen",
-        "not_equal": "ist nicht"
-      },
-      "enum": {
-        "equal": "ist",
-        "not_equal": "ist nicht"
-      },
-      "number": {
-        "between": "zwischen",
-        "equal": "ist",
-        "greater": "mehr als",
-        "greater_or_equal": "mindestens",
-        "less": "weniger als",
-        "less_or_equal": "höchstens",
-        "not_between": "nicht zwischen",
-        "not_equal": "ist nicht"
-      },
-      "text": {
-        "begins_with": "beginnt mit",
-        "contains": "enthält",
-        "ends_with": "endet mit",
-        "equal": "ist",
-        "not_begins_with": "beginnt nicht mit",
-        "not_contains": "enthält nicht",
-        "not_ends_with": "endet nicht mit",
-        "not_equal": "ist nicht"
-      }
-    },
-    "saveAsSegment": "Als Segment speichern",
-    "selectFilter": "Filter auswählen",
-    "showResults": "Suchen"
-  },
   "callout": {
     "contactDetails": "Kontaktdaten",
     "form": {
@@ -318,7 +253,6 @@
       "copy": "<p>Alle hier eingegebenen Information sind <strong>nur für Administratoren sichtbar</strong>.\nNutzer bekommen das nicht angezeigt.</p>\n"
     },
     "contribution": "Beitrag",
-    "contributionType": "Zahlungsart",
     "information": "Information",
     "newsletter": "Newsletter",
     "overview": "Überblick",
@@ -339,7 +273,7 @@
       "amount": "Betrag",
       "annotationsCopy": "Änderungen gespeichert!",
       "contribution": "Beitrag",
-      "contributionType": "Zahlungsart",
+      "contributionType": "Beitragsart",
       "deliveryOptIn": "Postsendung",
       "description": "Beschreibung",
       "email": "E-Mail",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -102,71 +102,6 @@
     },
     "title": "Einstellungen"
   },
-  "advancedSearch": {
-    "addRule": "Filter hinzufügen",
-    "button": "Erweiterte Suche",
-    "createFilters": "Filter für die Suche erstellen",
-    "matchAfter": "der folgenden Filter enthalten",
-    "matchBefore": "Ergebnisse sollen",
-    "matchType": {
-      "all": "alle",
-      "any": "mindestens einen"
-    },
-    "matchWord": {
-      "all": "und",
-      "any": "oder"
-    },
-    "operators": {
-      "all": {
-        "is_empty": "ist leer",
-        "is_not_empty": "ist nicht leer"
-      },
-      "array": {
-        "contains": "enthält",
-        "not_contains": "enthält nicht"
-      },
-      "boolean": {
-        "equal": "ist"
-      },
-      "date": {
-        "between": "zwischen",
-        "equal": "ist",
-        "greater": "nach",
-        "greater_or_equal": "nach oder am",
-        "less": "vor",
-        "less_or_equal": "vor oder am",
-        "not_between": "nicht zwischen",
-        "not_equal": "ist nicht"
-      },
-      "enum": {
-        "equal": "ist",
-        "not_equal": "ist nicht"
-      },
-      "number": {
-        "between": "zwischen",
-        "equal": "ist",
-        "greater": "mehr als",
-        "greater_or_equal": "mindestens",
-        "less": "weniger als",
-        "less_or_equal": "höchstens",
-        "not_between": "nicht zwischen",
-        "not_equal": "ist nicht"
-      },
-      "text": {
-        "begins_with": "beginnt mit",
-        "contains": "enthält",
-        "ends_with": "endet mit",
-        "equal": "ist",
-        "not_begins_with": "beginnt nicht mit",
-        "not_contains": "enthält nicht",
-        "not_ends_with": "endet nicht mit",
-        "not_equal": "ist nicht"
-      }
-    },
-    "saveAsSegment": "Als Segment speichern",
-    "selectFilter": "Filter auswählen",
-    "showResults": "Suchen"
-  },
   "callout": {
     "contactDetails": "Kontaktdaten",
     "form": {
@@ -318,7 +253,6 @@
       "copy": "<p>Alle hier eingegebenen Information sind <strong>nur für Administratoren sichtbar</strong>.\nNutzer bekommen das nicht angezeigt.</p>\n"
     },
     "contribution": "Beitrag",
-    "contributionType": "Zahlungsart",
     "information": "Information",
     "newsletter": "Newsletter",
     "overview": "Überblick",
@@ -339,7 +273,7 @@
       "amount": "Betrag",
       "annotationsCopy": "Änderungen gespeichert!",
       "contribution": "Beitrag",
-      "contributionType": "Zahlungsart",
+      "contributionType": "Beitragsart",
       "deliveryOptIn": "Postsendung",
       "description": "Beschreibung",
       "email": "E-Mail",

--- a/locales/en.json
+++ b/locales/en.json
@@ -102,71 +102,6 @@
     },
     "title": "Settings"
   },
-  "advancedSearch": {
-    "addRule": "Add rule",
-    "button": "Advanced",
-    "createFilters": "Create filters for your search",
-    "matchAfter": "of the following",
-    "matchBefore": "Match",
-    "matchType": {
-      "all": "all",
-      "any": "any"
-    },
-    "matchWord": {
-      "all": "and",
-      "any": "or"
-    },
-    "operators": {
-      "all": {
-        "is_empty": "is empty",
-        "is_not_empty": "isn't empty"
-      },
-      "array": {
-        "contains": "includes",
-        "not_contains": "doesn't include"
-      },
-      "boolean": {
-        "equal": "is"
-      },
-      "date": {
-        "between": "between",
-        "equal": "is",
-        "greater": "after",
-        "greater_or_equal": "after or on",
-        "less": "before",
-        "less_or_equal": "before or on",
-        "not_between": "isn't between",
-        "not_equal": "is not"
-      },
-      "enum": {
-        "equal": "is",
-        "not_equal": "is not"
-      },
-      "number": {
-        "between": "between",
-        "equal": "is",
-        "greater": "more than",
-        "greater_or_equal": "at least",
-        "less": "less than",
-        "less_or_equal": "at most",
-        "not_between": "isn't between",
-        "not_equal": "isn't"
-      },
-      "text": {
-        "begins_with": "begins with",
-        "contains": "contains",
-        "ends_with": "ends with",
-        "equal": "is",
-        "not_begins_with": "doesn't begin with",
-        "not_contains": "doesn't contain",
-        "not_ends_with": "doesn't end with",
-        "not_equal": "is not"
-      }
-    },
-    "saveAsSegment": "Save as segment",
-    "selectFilter": "Select a filter",
-    "showResults": "Show results"
-  },
   "callout": {
     "contactDetails": "Contact details",
     "form": {
@@ -318,7 +253,6 @@
       "copy": "<p>All information added in this section is <strong>visible for admins only</strong>. Members will never see these in their profile or member area.</p>\n"
     },
     "contribution": "Contribution",
-    "contributionType": "Type",
     "information": "Information",
     "newsletter": "Newsletter",
     "overview": "Overview",


### PR DESCRIPTION
Using the new changes #297, this removes all the advanced search related changes as they are in a branch sheet now