### PR TITLE
fix: improve callout content styling consistency

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,19 +2,33 @@
 @tailwind components;
 @tailwind utilities;
 
-.formio-component-content,
-.formio-dialog .formio-component-html .ck-content,
-.content-message {
+/* Apply link styles to i18n markdown text */
+.content-i18n {
+  a {
+    @apply text-link underline;
+  }
+}
+
+/* Apply standard styles to v-html content */
+.content-message,
+/* Apply standard styles to FormIO rendered forms */
+.callout-form,
+.callout-form-builder .formarea,
+/* Apply standard styles to FormIO popup preview */
+.formio-dialog .preview-panel,
+.formio-dialog .formio-component-html .ck-content {
   p,
   ul,
   ol {
     margin: 0;
   }
 
+  /* Force empty paragraphs to have height */
   p:empty::after {
     content: '\00A0';
   }
 
+  /* List styles */
   ul,
   ol {
     @apply relative ml-2 list-none pl-6;
@@ -36,31 +50,20 @@
     }
   }
 
+  /* Link and header styles */
   a {
     @apply text-link underline;
   }
-
   h3 {
     @apply font-title text-xl font-semibold;
   }
 }
 
-.content-i18n {
-  a {
-    @apply text-link;
-  }
-}
-
-.formio-component-content,
-.formio-dialog .formio-component-html .ck-content {
-  h3 {
-    @apply mb-2;
-  }
-}
-
+/* Force FormIO to fit in! Styles for renderer, builder and popup dialog */
 .callout-form,
 .callout-form-builder .formarea,
 .formio-dialog {
+  /* Input styling */
   .form-control {
     @apply w-full rounded border border-primary-40 bg-white p-2 focus:shadow-input focus:outline-none;
 
@@ -69,6 +72,7 @@
     }
   }
 
+  /* Button styling */
   .btn:not(.component-settings-button):not(.formcomponent) {
     @apply relative inline-flex h-10 cursor-pointer items-center justify-center whitespace-nowrap rounded bg-link px-2 text-center font-bold text-white;
 
@@ -103,27 +107,31 @@
       @apply w-full;
     }
 
+    /* Align font-awesome icons */
     &.svg-inline--fa {
-      @apply box-content box-content align-top;
+      @apply box-content align-top;
     }
   }
 
+  /* Choice select widget styling */
   .choices__list {
     @apply align-middle;
   }
-
   .formio-choices.form-group {
     @apply mb-0;
   }
 }
 
+/* Force FormIO to fit in! Styles for renderer (including preview) */
 .callout-form,
 .callout-form-builder .formarea,
 .formio-dialog .preview-panel {
+  /* Hide hidden controls */
   .formio-hidden {
     @apply hidden !important;
   }
 
+  /* Standard spacing for questions and flex to manipulate order */
   .formio-component-content,
   .form-group {
     @apply mb-8 flex flex-col;
@@ -133,23 +141,27 @@
     }
   }
 
+  /* Label always goes at the top, styled like .content-message h3 */
   .col-form-label {
     @apply -order-2 mb-2 block font-title text-xl font-semibold;
   }
-
+  /* Description goes next */
   .form-text {
     @apply -order-1 mb-2 text-body-80;
   }
 
+  /* Subtle style for check boxes */
   .formio-editor-read-only-content,
   .form-check-input {
     @apply accent-link;
   }
 
+  /* Inline checkboxes */
   .form-check-inline {
     @apply mr-4 inline-block;
   }
 
+  /* Block checkboxes */
   .form-check-label {
     @apply mb-2 flex align-baseline;
 
@@ -162,6 +174,7 @@
     @apply absolute -z-10 opacity-0;
   }
 
+  /* Styling for input errors */
   .formio-errors {
     @apply mt-1.5 text-sm font-semibold;
 
@@ -170,8 +183,17 @@
     }
   }
 
+  /* Add required asterisk */
   .field-required::after {
     @apply text-danger;
     content: '*';
+  }
+}
+
+/* Match header margin to form labels */
+.formio-component-content,
+.formio-dialog .formio-component-html .ck-content {
+  h3 {
+    @apply mb-2;
   }
 }


### PR DESCRIPTION
Make content styling more consistent between callouts and the rest of the site. I've also tried to add comments to all the CSS to make it easier to understand the hacks.