### PR TITLE
feat: add AppForm to standardise form submission handling

### DIFF
--- a/src/components/forms/AppForm.vue
+++ b/src/components/forms/AppForm.vue
@@ -1,0 +1,71 @@
+<template>
+  <form @submit.prevent="handleSubmit">
+    <slot />
+
+    <MessageBox v-if="hasSuccess && successText" class="mb-4" type="success">
+      {{ successText }}
+    </MessageBox>
+
+    <MessageBox v-if="hasError" class="mb-4" type="error">
+      {{ errorText }}
+    </MessageBox>
+
+    <MessageBox
+      v-if="validation.$errors.length > 0"
+      type="error"
+      class="mb-4"
+    />
+
+    <div class="flex gap-2">
+      <AppButton
+        type="submit"
+        variant="link"
+        :loading="isLoading"
+        :disabled="validation.$invalid"
+      >
+        {{ buttonText }}
+      </AppButton>
+      <AppButton v-if="resetButtonText" variant="text" @click="emit('reset')">
+        {{ resetButtonText }}
+      </AppButton>
+    </div>
+  </form>
+</template>
+<script lang="ts" setup>
+import useVuelidate from '@vuelidate/core';
+import { ref } from 'vue';
+import MessageBox from '../MessageBox.vue';
+import AppButton from './AppButton.vue';
+
+const emit = defineEmits(['reset']);
+const props = defineProps<{
+  buttonText: string;
+  resetButtonText?: string;
+  successText?: string;
+  errorText?: string;
+  onSubmit?: (evt: Event) => Promise<unknown>;
+}>();
+
+const isLoading = ref(false);
+const hasError = ref(false);
+const hasSuccess = ref(false);
+
+const validation = useVuelidate();
+
+async function handleSubmit(evt: Event) {
+  isLoading.value = true;
+  hasError.value = false;
+  hasSuccess.value = false;
+
+  try {
+    if (props.onSubmit) {
+      await props.onSubmit(evt);
+    }
+    hasSuccess.value = true;
+  } catch {
+    hasError.value = true;
+  } finally {
+    isLoading.value = false;
+  }
+}
+</script>

--- a/src/components/pages/profile/information/ChangePassword.vue
+++ b/src/components/pages/profile/information/ChangePassword.vue
@@ -6,6 +6,7 @@
   <MessageBox v-if="saved" class="mb-4" type="success">{{
     t('informationPage.savedPassword')
   }}</MessageBox>
+
   <AppButton
     v-if="!showForm"
     variant="primaryOutlined"
@@ -17,8 +18,15 @@
   >
     {{ t('informationPage.changePassword') }}
   </AppButton>
-  <form v-else @submit.prevent="handleFormSubmit">
-    <div class="mb-5">
+
+  <AppForm
+    v-else
+    :button-text="t('form.saveChanges')"
+    :reset-button-text="t('form.cancel')"
+    @submit="handleFormSubmit"
+    @reset="showForm = false"
+  >
+    <div class="mb-4">
       <AppInput
         v-model="password"
         type="password"
@@ -28,7 +36,7 @@
         :info-message="t('form.passwordInfo')"
       />
     </div>
-    <div class="mb-5">
+    <div class="mb-4">
       <AppInput
         v-model="confirmPassword"
         type="password"
@@ -38,61 +46,32 @@
         :label="t('form.newPasswordConfirm')"
       />
     </div>
-    <MessageBox v-if="hasFormError" type="error" class="mt-2" />
-    <div class="mt-2 flex">
-      <AppButton
-        type="submit"
-        :disabled="disableSubmit"
-        :loading="loading"
-        variant="link"
-        >{{ t('form.saveChanges') }}</AppButton
-      >
-      <AppButton variant="text" class="ml-2" @click="showForm = false">{{
-        t('form.cancel')
-      }}</AppButton>
-    </div>
-  </form>
+  </AppForm>
 </template>
 <script lang="ts" setup>
-import useVuelidate from '@vuelidate/core';
-import { computed, onBeforeMount, ref } from 'vue';
+import { onBeforeMount, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { updateMember } from '../../../../utils/api/member';
 import AppButton from '../../../forms/AppButton.vue';
 import MessageBox from '../../../MessageBox.vue';
 import AppInput from '../../../forms/AppInput.vue';
 import AppHeading from '../../../AppHeading.vue';
+import AppForm from '../../../forms/AppForm.vue';
 
 const { t } = useI18n();
 
 const showForm = ref(false);
-const loading = ref(false);
 const saved = ref(false);
 const password = ref('');
 const confirmPassword = ref('');
 
-const validation = useVuelidate();
-
-const hasFormError = computed(() => validation.value.$errors.length > 0);
-
-const disableSubmit = computed(
-  () => hasFormError.value || password.value === ''
-);
-
 async function handleFormSubmit() {
-  loading.value = true;
-
-  try {
-    await updateMember('me', { password: password.value });
-    saved.value = true;
-    showForm.value = false;
-  } finally {
-    loading.value = false;
-  }
+  await updateMember('me', { password: password.value });
+  saved.value = true;
+  showForm.value = false;
 }
 
 onBeforeMount(() => {
-  loading.value = false;
   saved.value = false;
   showForm.value = false;
   password.value = '';

--- a/src/components/pages/profile/information/UpdateContactInformation.vue
+++ b/src/components/pages/profile/information/UpdateContactInformation.vue
@@ -1,5 +1,9 @@
 <template>
-  <form @submit.prevent="handleSubmit()">
+  <AppForm
+    :button-text="t('form.saveChanges')"
+    :success-text="t('form.saved')"
+    @submit="handleSubmit"
+  >
     <AppHeading class="mt-6 mb-2">
       {{ t('informationPage.contactInformation') }}
     </AppHeading>
@@ -42,40 +46,19 @@
       v-model:cityOrTown="information.cityOrTown"
       :required="information.deliveryOptIn"
     />
-
-    <MessageBox
-      v-if="validation.$errors.length > 0"
-      type="error"
-      class="mt-2"
-    />
-
-    <MessageBox v-if="isSaved" type="success" class="mt-2">
-      {{ t('form.saved') }}
-    </MessageBox>
-
-    <AppButton
-      type="submit"
-      :disabled="validation.$invalid"
-      class="mt-6"
-      :loading="loading"
-      variant="link"
-      >{{ t('form.saveChanges') }}</AppButton
-    >
-  </form>
+  </AppForm>
 </template>
 <script lang="ts" setup>
-import AppButton from '../../../forms/AppButton.vue';
 import ContactInformation from '../../../ContactInformation.vue';
-import MessageBox from '../../../MessageBox.vue';
 import AppAddress from '../../../AppAddress.vue';
 import ContactMailOptIn from '../../../ContactMailOptIn.vue';
 import { useI18n } from 'vue-i18n';
-import { computed, reactive, ref, toRef, watch } from 'vue';
+import { computed, reactive, toRef, watch } from 'vue';
 import AppHeading from '../../../AppHeading.vue';
-import useVuelidate from '@vuelidate/core';
 import { fetchContent } from '../../../../utils/api/content';
 import { fetchMember, updateMember } from '../../../../utils/api/member';
 import AppRadioGroup from '../../../forms/AppRadioGroup.vue';
+import AppForm from '../../../forms/AppForm.vue';
 
 const props = defineProps<{
   id: string;
@@ -84,8 +67,6 @@ const props = defineProps<{
 const { t } = useI18n();
 
 const isAdmin = computed(() => props.id !== 'me');
-const loading = ref(false);
-const isSaved = ref(false);
 
 const infoContent = await fetchContent('join/setup');
 
@@ -119,32 +100,22 @@ watch(
   { immediate: true }
 );
 
-const validation = useVuelidate();
-
 async function handleSubmit() {
-  loading.value = true;
-  isSaved.value = false;
-
-  try {
-    await updateMember(props.id, {
-      email: information.emailAddress,
-      firstname: information.firstName,
-      lastname: information.lastName,
-      profile: {
-        ...(infoContent.showMailOptIn && {
-          deliveryOptIn: information.deliveryOptIn,
-        }),
-        deliveryAddress: {
-          line1: information.addressLine1,
-          line2: information.addressLine2,
-          city: information.cityOrTown,
-          postcode: information.postCode,
-        },
+  await updateMember(props.id, {
+    email: information.emailAddress,
+    firstname: information.firstName,
+    lastname: information.lastName,
+    profile: {
+      ...(infoContent.showMailOptIn && {
+        deliveryOptIn: information.deliveryOptIn,
+      }),
+      deliveryAddress: {
+        line1: information.addressLine1,
+        line2: information.addressLine2,
+        city: information.cityOrTown,
+        postcode: information.postCode,
       },
-    });
-    isSaved.value = true;
-  } finally {
-    loading.value = false;
-  }
+    },
+  });
 }
 </script>

--- a/src/pages/admin/contacts/[id]/index.vue
+++ b/src/pages/admin/contacts/[id]/index.vue
@@ -89,7 +89,11 @@ meta:
         v-html="t('contactOverview.annotation.copy')"
       />
 
-      <form @submit.prevent="handleFormSubmit">
+      <AppForm
+        :button-text="t('form.saveChanges')"
+        :success-text="t('contacts.data.annotationsCopy')"
+        @submit.prevent="handleFormSubmit"
+      >
         <div class="mb-4">
           <AppInput
             v-model="contactAnnotations.description"
@@ -101,23 +105,15 @@ meta:
           :label="t('contacts.data.notes')"
           class="mb-4"
         />
-        <TagDropdown
-          v-if="contactTags.length > 0"
-          v-model="contactAnnotations.tags"
-          :tags="contactTags"
-          label="Tags"
-        />
-        <AppButton
-          type="submit"
-          variant="primary"
-          class="mt-4"
-          :loading="loading"
-          >{{ t('form.saveChanges') }}</AppButton
-        >
-      </form>
-      <MessageBox v-if="hasSetAnnotations" type="success" class="mt-5">
-        {{ t('contacts.data.annotationsCopy') }}
-      </MessageBox>
+        <div class="mb-4">
+          <TagDropdown
+            v-if="contactTags.length > 0"
+            v-model="contactAnnotations.tags"
+            :tags="contactTags"
+            label="Tags"
+          />
+        </div>
+      </AppForm>
     </div>
 
     <div>
@@ -129,22 +125,12 @@ meta:
       <AppHeading>{{ t('contactOverview.security.title') }}</AppHeading>
       <p>{{ t('contactOverview.security.whatDoTheButtonsDo') }}</p>
       <form @submit.prevent="handleSecurityAction">
-        <AppButton
-          type="submit"
-          variant="primaryOutlined"
-          :disabled="securityButtonsDisabled"
-          :loading="loading"
-          class="mt-4"
-          >{{ t('contactOverview.security.loginOverride') }}</AppButton
-        >
-        <AppButton
-          type="submit"
-          variant="primaryOutlined"
-          :disabled="securityButtonsDisabled"
-          :loading="loading"
-          class="mt-2 ml-6"
-          >{{ t('contactOverview.security.resetPassword') }}</AppButton
-        >
+        <AppButton type="submit" variant="primaryOutlined" class="mt-4">{{
+          t('contactOverview.security.loginOverride')
+        }}</AppButton>
+        <AppButton type="submit" variant="primaryOutlined" class="mt-2 ml-6">{{
+          t('contactOverview.security.resetPassword')
+        }}</AppButton>
       </form>
       <div v-if="securityLink" class="mt-4">
         <p class="mt-4">{{ t('contactOverview.security.instructions') }}</p>
@@ -162,7 +148,6 @@ import AppInput from '../../../../components/forms/AppInput.vue';
 import AppButton from '../../../../components/forms/AppButton.vue';
 import TagDropdown from '../../../../components/pages/admin/contacts/TagDropdown.vue';
 import RoleEditor from '../../../../components/pages/admin/contacts/RoleEditor.vue';
-import MessageBox from '../../../../components/MessageBox.vue';
 import { onBeforeMount, ref, reactive } from 'vue';
 import {
   GetMemberData,
@@ -174,6 +159,7 @@ import AppInfoListItem from '../../../../components/AppInfoListItem.vue';
 import { formatLocale } from '../../../../utils/dates/locale-date-formats';
 import { fetchContent } from '../../../../utils/api/content';
 import RichTextEditor from '../../../../components/rte/RichTextEditor.vue';
+import AppForm from '../../../../components/forms/AppForm.vue';
 
 formatLocale;
 
@@ -187,9 +173,6 @@ const contact = ref<GetMemberDataWith<
   'profile' | 'contribution' | 'roles'
 > | null>(null);
 const contactTags = ref<string[]>([]);
-const loading = ref(false);
-const hasSetAnnotations = ref(false);
-const securityButtonsDisabled = ref(false);
 const contactAnnotations = reactive({
   notes: '',
   description: '',
@@ -198,26 +181,14 @@ const contactAnnotations = reactive({
 const securityLink = ref('');
 
 async function handleFormSubmit() {
-  loading.value = true;
-  try {
-    await updateMember(props.contact.id, {
-      profile: { ...contactAnnotations },
-    });
-  } finally {
-    loading.value = false;
-    hasSetAnnotations.value = true;
-  }
+  await updateMember(props.contact.id, {
+    profile: { ...contactAnnotations },
+  });
 }
 
 async function handleSecurityAction() {
-  securityButtonsDisabled.value = true;
-  loading.value = true;
-  try {
-    const response = await (() => 'https://reset-link.com')();
-    securityLink.value = response;
-  } finally {
-    loading.value = false;
-  }
+  const response = await (() => 'https://reset-link.com')();
+  securityLink.value = response;
 }
 
 async function handleUpdate() {
@@ -229,9 +200,6 @@ async function handleUpdate() {
 }
 
 onBeforeMount(async () => {
-  loading.value = false;
-  securityButtonsDisabled.value = false;
-
   contact.value = await fetchMember(props.contact.id, [
     'profile',
     'contribution',

--- a/src/pages/admin/settings/email.vue
+++ b/src/pages/admin/settings/email.vue
@@ -7,7 +7,12 @@ meta:
 
 <template>
   <div class="grid gap-8 lg:grid-cols-2">
-    <form v-if="emailContent.footer" @submit.prevent="handleSubmit">
+    <AppForm
+      v-if="emailContent.footer"
+      :button-text="t('actions.update')"
+      :success-text="t('form.saved')"
+      @submit="handleSubmit"
+    >
       <AppHeading class="mb-4">{{ t('adminSettings.email.title') }}</AppHeading>
       <p class="mb-4">{{ t('adminSettings.email.text') }}</p>
       <div class="mb-4 max-w-[25rem]">
@@ -28,39 +33,19 @@ meta:
           required
         />
       </div>
-
-      <MessageBox v-if="hasSaved" type="success" class="mb-4">
-        {{ t('form.saved') }}
-      </MessageBox>
-
-      <MessageBox v-if="validation.$errors.length > 0" class="mb-4">
-        {{ t('form.errors.aggregator') }}
-      </MessageBox>
-
-      <AppButton
-        type="submit"
-        variant="link"
-        :loading="saving"
-        :disabled="validation.$invalid"
-      >
-        {{ t('actions.update') }}
-      </AppButton>
-    </form>
+    </AppForm>
   </div>
 </template>
 <script lang="ts" setup>
-import useVuelidate from '@vuelidate/core';
 import { computed, onBeforeMount, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import AppHeading from '../../../components/AppHeading.vue';
-import AppButton from '../../../components/forms/AppButton.vue';
+import AppForm from '../../../components/forms/AppForm.vue';
 import AppInput from '../../../components/forms/AppInput.vue';
-import MessageBox from '../../../components/MessageBox.vue';
 import { EmailContent } from '../../../utils/api/api.interface';
 import { fetchContent, updateContent } from '../../../utils/api/content';
 
 const { t } = useI18n();
-const validation = useVuelidate();
 
 const emailContent = ref<EmailContent>({
   footer: '',
@@ -83,18 +68,8 @@ const fromEmailDomain = computed(() => {
   return emailContent.value.supportEmail.slice(i);
 });
 
-const hasSaved = ref(false);
-const saving = ref(false);
-
 async function handleSubmit() {
-  saving.value = true;
-  hasSaved.value = false;
-  try {
-    await updateContent('email', emailContent.value);
-    hasSaved.value = true;
-    // eslint-disable-next-line no-empty
-  } catch (err) {}
-  saving.value = false;
+  await updateContent('email', emailContent.value);
 }
 
 onBeforeMount(async () => {


### PR DESCRIPTION
This PR adds an `AppForm` component that standardises the handling of validation errors and submission loading, success and failure states.

This means:
* Automatically enabling/disabling submit button while form is failing validation
* Showing the validation error message when appropriate
* Showing a success message using the standard MessageBox
* Handling the loading state for async form handlers

https://user-images.githubusercontent.com/2084823/204860939-410eab9f-04bf-4682-bead-f2fc1fc65146.mp4

To create a standard form you can now create an `AppForm` and just define your inputs, no other work is required. e.g.
```vue
<AppForm
  :button-text="t('action.saveChanges')"
  :success-text="t('form.saved')"
  @submit="handleSubmit"
>
  <AppInput ../>
  <AppInput ../>
  <AppInput ../>
  <AppInput ../>
  <!-- etc.. -->
</AppForm>
<script lang="ts" setup>
async function handleSubmit() {
  await someAsyncMethod();
}
</script>
```

