### PR TITLE
chore: remove edit button in favour of link to view

### DIFF
--- a/src/components/callout/CalloutSummary.vue
+++ b/src/components/callout/CalloutSummary.vue
@@ -10,7 +10,7 @@
       </div>
     </div>
     <p>
-      <router-link :to="calloutLink">
+      <router-link :to="calloutLink" class="relative z-10">
         <font-awesome-icon icon="external-link-alt" />
         <span class="ml-2 text-link">{{ env.appUrl }}{{ calloutLink }}</span>
       </router-link>
@@ -27,7 +27,10 @@
             <b>{{ callout.responseCount }}</b>
           </template>
         </i18n-t>
-        <router-link :to="`/admin/callouts/view/${callout.slug}/responses`">
+        <router-link
+          :to="`/admin/callouts/view/${callout.slug}/responses`"
+          class="relative z-10"
+        >
           <p class="text-sm font-semibold text-link">
             {{ t('adminDashboard.seeAllResponses') }}
           </p>
@@ -43,13 +46,6 @@
           {{ callout.expires && formatLocale(callout.expires, 'PP') }}
         </p>
       </div>
-      <AppButton
-        v-if="edit"
-        class="ml-2"
-        :to="`/admin/callouts/edit/${callout.slug}`"
-      >
-        {{ t('actions.edit') }}
-      </AppButton>
     </div>
   </div>
 </template>
@@ -60,7 +56,6 @@ import {
   GetCalloutData,
   GetCalloutDataWith,
 } from '../../utils/api/api.interface';
-import AppButton from '../forms/AppButton.vue';
 import { formatLocale } from '../../utils/dates/locale-date-formats';
 import AppSubHeading from '../AppSubHeading.vue';
 import env from './../../env';
@@ -70,7 +65,6 @@ const { t } = useI18n();
 
 const props = defineProps<{
   callout: GetCalloutData | GetCalloutDataWith<'responseCount'>;
-  edit?: boolean;
 }>();
 
 const calloutLink = computed(() => `/callouts/${props.callout.slug}`);

--- a/src/pages/admin/index.vue
+++ b/src/pages/admin/index.vue
@@ -59,8 +59,14 @@ meta:
     </div>
     <div class="flex-1 basis-7/12">
       <AppHeading>{{ t('adminDashboard.latestCallout.title') }}</AppHeading>
-      <div class="mt-4 mb-8 block rounded bg-white p-4">
-        <CalloutSummary v-if="latestCallout" :callout="latestCallout" edit />
+      <div class="relative mt-4 mb-8 block rounded bg-white p-4">
+        <div v-if="latestCallout">
+          <CalloutSummary :callout="latestCallout" />
+          <router-link
+            class="absolute inset-0"
+            :to="'/admin/callouts/view/' + latestCallout.slug"
+          />
+        </div>
         <div v-else-if="latestCallout === null">
           {{ t('adminDashboard.latestCallout.empty') }}
           <router-link to="/admin/callouts/new" class="text-link">


### PR DESCRIPTION
Small UI papercut change we agreed before Christmas: admins probably don't want to go directly to editing a callout from the dashboard, but they might want to view it. This PR removes the button in favour of being able to click on the box and goes to `/view/` instead of `/edit/`

Before:

![image](https://user-images.githubusercontent.com/2084823/210603083-4a0d9190-4449-49c9-af46-86e9c8b3a56e.png)

After:

![image](https://user-images.githubusercontent.com/2084823/210603019-0b5f0b79-55b7-4a4f-a565-1a5670f263e1.png)