### PR TITLE
refactor: simpler types for API methods with a With param

### DIFF
--- a/src/utils/api/api.interface.ts
+++ b/src/utils/api/api.interface.ts
@@ -11,8 +11,10 @@ import {
   RuleGroup,
 } from '@beabee/beabee-common';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface Noop {}
+// Not really sure why but this work for conditional intersections
+// https://stackoverflow.com/questions/65549362/how-to-create-a-conditional-intersection-based-on-a-generic-parameter
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Noop = {};
 
 // Dates are serialized in API response
 export type Serial<T> = {
@@ -82,7 +84,7 @@ export interface GetContactData extends ContactData {
   activeRoles: RoleType[];
 }
 
-export type GetContactWith = 'profile' | 'contribution' | 'roles';
+export type GetContactWith = 'profile' | 'contribution' | 'roles' | void;
 
 export type GetContactDataWith<With extends GetContactWith> = GetContactData &
   ('profile' extends With ? { profile: ContactProfileData } : Noop) &
@@ -311,7 +313,7 @@ export interface CalloutFormSchema {
   components: unknown[];
 }
 
-export type GetCalloutWith = 'form' | 'responseCount' | 'hasAnswered';
+export type GetCalloutWith = 'form' | 'responseCount' | 'hasAnswered' | void;
 
 export type GetCalloutDataWith<With extends GetCalloutWith> = GetCalloutData &
   ('responseCount' extends With ? { responseCount: number } : Noop) &
@@ -387,7 +389,7 @@ export interface CreateSegmentData {
 
 export type UpdateSegmentData = Partial<CreateSegmentData>;
 
-export type GetSegmentWith = 'contactCount';
+export type GetSegmentWith = 'contactCount' | void;
 
 export type GetSegmentDataWith<With extends GetSegmentWith> = GetSegmentData &
   ('contactCount' extends With ? { contactCount: number } : Noop);

--- a/src/utils/api/callout.ts
+++ b/src/utils/api/callout.ts
@@ -23,14 +23,7 @@ function deserializeCallout(callout: any): any {
   };
 }
 
-export async function fetchCallouts(
-  query: GetCalloutsQuery
-): Promise<Paginated<GetCalloutData>>;
-export async function fetchCallouts<With extends GetCalloutWith>(
-  query: GetCalloutsQuery,
-  _with: readonly With[]
-): Promise<Paginated<GetCalloutDataWith<With>>>;
-export async function fetchCallouts<With extends GetCalloutWith>(
+export async function fetchCallouts<With extends GetCalloutWith = void>(
   query?: GetCalloutsQuery,
   _with?: readonly With[]
 ): Promise<Paginated<GetCalloutDataWith<With>>> {
@@ -44,12 +37,7 @@ export async function fetchCallouts<With extends GetCalloutWith>(
   };
 }
 
-export async function fetchCallout(id: string): Promise<GetCalloutData>;
-export async function fetchCallout<With extends GetCalloutWith>(
-  id: string,
-  _with: readonly With[]
-): Promise<GetCalloutDataWith<With>>;
-export async function fetchCallout<With extends GetCalloutWith>(
+export async function fetchCallout<With extends GetCalloutWith = void>(
   id: string,
   _with?: readonly With[]
 ): Promise<GetCalloutDataWith<With>> {

--- a/src/utils/api/contact.ts
+++ b/src/utils/api/contact.ts
@@ -63,15 +63,8 @@ function deserializeContribution(
   };
 }
 
-export async function fetchContacts(
-  query: GetContactsQuery
-): Promise<Paginated<GetContactData>>;
-export async function fetchContacts<With extends GetContactWith>(
+export async function fetchContacts<With extends GetContactWith = void>(
   query: GetContactsQuery,
-  _with: readonly With[]
-): Promise<Paginated<GetContactDataWith<With>>>;
-export async function fetchContacts<With extends GetContactWith>(
-  query: GetContactsQuery = {},
   _with?: readonly With[]
 ): Promise<Paginated<GetContactDataWith<With>>> {
   // TODO: fix type safety
@@ -91,18 +84,16 @@ export async function createContact(
   return deserializeContact(data);
 }
 
-export async function fetchContact(id: string): Promise<GetContactData>;
-export async function fetchContact<With extends GetContactWith>(
-  id: string,
-  _with: readonly With[]
-): Promise<GetContactDataWith<With>>;
-export async function fetchContact<With extends GetContactWith>(
+export async function fetchContact<With extends GetContactWith = void>(
   id: string,
   _with?: readonly With[]
 ): Promise<GetContactDataWith<With>> {
-  const { data } = await axios.get<Serial<GetContactData>>(`/contact/${id}`, {
-    params: { with: _with },
-  });
+  const { data } = await axios.get<Serial<GetContactDataWith<With>>>(
+    `/contact/${id}`,
+    {
+      params: { with: _with },
+    }
+  );
   return deserializeContact(data);
 }
 

--- a/src/utils/api/segments.ts
+++ b/src/utils/api/segments.ts
@@ -1,24 +1,14 @@
-import { Paginated } from '@beabee/beabee-common';
 import axios from '../../lib/axios';
 import {
   CreateSegmentData,
-  GetContactData,
-  GetContactDataWith,
-  GetContactsQuery,
-  GetContactWith,
   GetSegmentData,
   GetSegmentDataWith,
   GetSegmentWith,
   Serial,
   UpdateSegmentData,
 } from './api.interface';
-import { deserializeContact } from './contact';
 
-export async function fetchSegments(): Promise<GetSegmentData[]>;
-export async function fetchSegments<With extends GetSegmentWith>(
-  _with: readonly With[]
-): Promise<GetSegmentDataWith<With>[]>;
-export async function fetchSegments<With extends GetSegmentWith>(
+export async function fetchSegments<With extends GetSegmentWith = void>(
   _with?: readonly With[]
 ): Promise<GetSegmentDataWith<With>[]> {
   const { data } = await axios.get<Serial<GetSegmentDataWith<With>>[]>(
@@ -27,21 +17,18 @@ export async function fetchSegments<With extends GetSegmentWith>(
       params: { with: _with },
     }
   );
+  // TODO: needs Serial type guard
   return data as GetSegmentDataWith<With>[];
 }
 
-export async function fetchSegment(id: string): Promise<GetSegmentData>;
-export async function fetchSegment<With extends GetSegmentWith>(
-  id: string,
-  _with: readonly With[]
-): Promise<GetSegmentDataWith<With>>;
-export async function fetchSegment<With extends GetSegmentWith>(
+export async function fetchSegment<With extends GetSegmentWith = void>(
   id: string,
   _with?: readonly With[]
 ): Promise<GetSegmentDataWith<With>> {
   const { data } = await axios.get<Serial<GetSegmentData>>('/segments/' + id, {
     params: { with: _with },
   });
+  // TODO: needs Serial type guard
   return data as GetSegmentDataWith<With>;
 }
 
@@ -76,28 +63,4 @@ export async function updateSegment(
 
 export async function deleteSegment(id: string): Promise<void> {
   await axios.delete('/segments/' + id);
-}
-
-export async function fetchSegmentContacts(
-  id: string,
-  query: GetContactsQuery
-): Promise<Paginated<GetContactData>>;
-export async function fetchSegmentContacts<With extends GetContactWith>(
-  id: string,
-  query: GetContactsQuery,
-  _with: readonly With[]
-): Promise<Paginated<GetContactDataWith<With>>>;
-export async function fetchSegmentContacts<With extends GetContactWith>(
-  id: string,
-  query: GetContactsQuery = {},
-  _with?: readonly With[]
-): Promise<Paginated<GetContactDataWith<With>>> {
-  const { data } = await axios.get(`/segments/${id}/contacts`, {
-    params: { with: _with, ...query },
-  });
-
-  return {
-    ...data,
-    items: data.items.map(deserializeContact),
-  };
 }


### PR DESCRIPTION
A quick change to simplify the types for various methods that have a `With` generic.

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `npm run check` and addressed any problems
- [x] PR doesn't have merge conflicts
