### PR TITLE
feat!: use new responses endpoint API

### DIFF
--- a/src/pages/callouts/[id].vue
+++ b/src/pages/callouts/[id].vue
@@ -115,7 +115,7 @@ import { useI18n } from 'vue-i18n';
 import {
   CalloutResponseAnswers,
   GetCalloutDataWith,
-  GetCalloutResponseData,
+  GetCalloutResponseDataWith,
 } from '../../utils/api/api.interface';
 import {
   createResponse,
@@ -144,7 +144,8 @@ const route = useRoute();
 const isPreview = computed(() => route.query.preview === null);
 
 const callout = ref<GetCalloutDataWith<'form'>>();
-const currentUserResponses = ref<Paginated<GetCalloutResponseData>>();
+const currentUserResponses =
+  ref<Paginated<GetCalloutResponseDataWith<'answers'>>>();
 
 const guestName = ref('');
 const guestEmail = ref('');
@@ -251,14 +252,18 @@ onBeforeMount(async () => {
   callout.value = await fetchCallout(props.id, ['form']);
 
   currentUserResponses.value = currentUser.value
-    ? await fetchResponses(props.id, {
-        rules: {
-          condition: 'AND',
-          rules: [{ field: 'contact', operator: 'equal', value: ['me'] }],
+    ? await fetchResponses(
+        props.id,
+        {
+          rules: {
+            condition: 'AND',
+            rules: [{ field: 'contact', operator: 'equal', value: ['me'] }],
+          },
+          sort: 'createdAt',
+          order: 'DESC',
         },
-        sort: 'createdAt',
-        order: 'DESC',
-      })
+        ['answers']
+      )
     : { total: 0, count: 0, offset: 0, items: [] };
 });
 </script>

--- a/src/utils/api/api.interface.ts
+++ b/src/utils/api/api.interface.ts
@@ -335,7 +335,7 @@ type CalloutResponseAnswer =
 export type CalloutResponseAnswers = Record<string, CalloutResponseAnswer>;
 
 export interface GetCalloutResponseData {
-  answers: CalloutResponseAnswers;
+  id: string;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -345,6 +345,13 @@ export interface CreateCalloutResponseData {
   guestEmail?: string;
   answers: CalloutResponseAnswers;
 }
+
+export type GetCalloutResponseWith = 'answers' | 'contact' | void;
+
+export type GetCalloutResponseDataWith<With extends GetCalloutResponseWith> =
+  GetCalloutResponseData &
+    ('answers' extends With ? { answers: CalloutResponseAnswers } : Noop) &
+    ('contact' extends With ? { contact: GetContactData } : Noop);
 
 export type GetNoticesQuery = PaginatedQuery; // TODO: constrain fields
 


### PR DESCRIPTION
Use the new responses API which requires `?with[]=answers` to load `answers`. This changed has been cherry picked from #346 so we can do a `v2.14` release with the backend

## Checklist before requesting a review
- [x] Done a self-review of my code
- [x] Run `npm run check` and addressed any problems
- [x] PR doesn't have merge conflicts
