### PR TITLE
fix: add translation for tag dropdown

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -50,7 +50,6 @@
       "text": "Text",
       "url": "URL"
     },
-    "noticeSaved": "Hinweis gespeichert",
     "title": "Hinweis hinzufügen"
   },
   "adminDashboard": {
@@ -813,6 +812,7 @@
     "notice": "Indem Sie fortfahren, akzeptieren Sie unsere",
     "now": "Jetzt Mitglied werden! ",
     "paymentMethod": "Zahlungsart",
+    "poweredBy": "Powered by beabee",
     "privacy": "Datenschutzerklärung"
   },
   "joinPayment": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -390,6 +390,7 @@
     "information": "Information",
     "newsletter": "Newsletter",
     "overview": "Überblick",
+    "pickTag": "Tag aus der Liste wählen",
     "roles": "Rolle",
     "security": {
       "instructions": "Link kopieren und teilen:",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -50,7 +50,6 @@
       "text": "Text",
       "url": "URL"
     },
-    "noticeSaved": "Hinweis gespeichert",
     "title": "Hinweis hinzufügen"
   },
   "adminDashboard": {
@@ -813,6 +812,7 @@
     "notice": "Indem du fortfährst, akzeptierst Du unsere",
     "now": "Jetzt Mitglied werden! ",
     "paymentMethod": "Zahlungsart",
+    "poweredBy": "Powered by beabee",
     "privacy": "Datenschutzerklärung"
   },
   "joinPayment": {

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -390,6 +390,7 @@
     "information": "Information",
     "newsletter": "Newsletter",
     "overview": "Überblick",
+    "pickTag": "Tag aus der Liste wählen",
     "roles": "Rolle",
     "security": {
       "instructions": "Link kopieren und teilen:",

--- a/locales/en.json
+++ b/locales/en.json
@@ -50,7 +50,6 @@
       "text": "Text",
       "url": "URL"
     },
-    "noticeSaved": "Notice saved",
     "title": "Add a notice"
   },
   "adminDashboard": {
@@ -391,6 +390,7 @@
     "information": "Information",
     "newsletter": "Newsletter",
     "overview": "Overview",
+    "pickTag": "Pick a tag from the list below",
     "roles": "Roles",
     "security": {
       "instructions": "Copy and share this link:",

--- a/src/components/pages/admin/contacts/TagDropdown.vue
+++ b/src/components/pages/admin/contacts/TagDropdown.vue
@@ -20,7 +20,7 @@
           class="mr-2 ml-2 inline-block cursor-pointer"
           icon="caret-down"
         />
-        Pick a tag from the list below
+        {{ t('contactOverview.pickTag') }}
       </p>
       <div :class="isTagMenuVisible ? 'block' : 'hidden'" class="">
         <p
@@ -43,15 +43,18 @@
 <script lang="ts" setup>
 import { ref } from 'vue';
 import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 import ContactTag from '../../../contact/ContactTag.vue';
 import AppLabel from '../../../forms/AppLabel.vue';
 
+const emit = defineEmits(['update:modelValue']);
 const props = defineProps<{
   tags: string[];
   modelValue: string[];
   label?: string;
 }>();
-const emit = defineEmits(['update:modelValue']);
+
+const { t } = useI18n();
 
 const isTagMenuVisible = ref(false);
 

--- a/src/pages/admin/contacts/[id]/index.vue
+++ b/src/pages/admin/contacts/[id]/index.vue
@@ -110,7 +110,7 @@ meta:
             v-if="contactTags.length > 0"
             v-model="contactAnnotations.tags"
             :tags="contactTags"
-            label="Tags"
+            :label="t('contacts.data.tags')"
           />
         </div>
       </AppForm>


### PR DESCRIPTION
Adds a missing translation for the tag dropdown on the contact overview page

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `npm run check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
