### PR TITLE
feat: add inline answer and comment view to response table

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -293,6 +293,7 @@
       "updatedAt": "Geändert am"
     },
     "dataGroup": {
+      "answers": "Fragen",
       "response": "Antwort"
     }
   },

--- a/locales/de.json
+++ b/locales/de.json
@@ -331,6 +331,8 @@
     "responseNo": "Antwort {no}",
     "searchAssignee": "Zugewiesen an...",
     "searchTag": "Getaggt mit...",
+    "showAnswer": "Antwort",
+    "showLatestComment": "Letzter Kommentar",
     "showingOf": "Antworten {start} bis {end} von {total} werden angezeigt"
   },
   "callouts": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -341,7 +341,6 @@
     },
     "noArchivedCallouts": "Keine Callouts",
     "search": "Callouts durchsuchen",
-    "show": "Anzeigen",
     "showAll": "Alle",
     "showAnswered": "Beantwortet",
     "showingOf": "Callouts {start} bis {end} von {total} werden angezeigt."
@@ -401,6 +400,7 @@
       "superadmin": "Überadmin"
     },
     "share": "Teilen",
+    "show": "Anzeigen",
     "status": {
       "draft": "Entwurf",
       "ended": "Beendet",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -293,6 +293,7 @@
       "updatedAt": "Geändert am"
     },
     "dataGroup": {
+      "answers": "Fragen",
       "response": "Antwort"
     }
   },

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -331,6 +331,8 @@
     "responseNo": "Antwort {no}",
     "searchAssignee": "Zugewiesen an...",
     "searchTag": "Getaggt mit...",
+    "showAnswer": "Antwort",
+    "showLatestComment": "Letzter Kommentar",
     "showingOf": "Antworten {start} bis {end} von {total} werden angezeigt"
   },
   "callouts": {

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -341,7 +341,6 @@
     },
     "noArchivedCallouts": "Keine Callouts",
     "search": "Callouts durchsuchen",
-    "show": "Anzeigen",
     "showAll": "Alle",
     "showAnswered": "Beantwortet",
     "showingOf": "Callouts {start} bis {end} von {total} werden angezeigt."
@@ -401,6 +400,7 @@
       "superadmin": "Überadmin"
     },
     "share": "Teilen",
+    "show": "Anzeigen",
     "status": {
       "draft": "Entwurf",
       "ended": "Beendet",

--- a/locales/en.json
+++ b/locales/en.json
@@ -343,7 +343,6 @@
     },
     "noArchivedCallouts": "No callouts",
     "search": "Search callouts...",
-    "show": "Show",
     "showAll": "All",
     "showAnswered": "Answered",
     "showingOf": "Showing {start} to {end} callouts out of {total}"
@@ -404,6 +403,7 @@
     },
     "selectOne": "Select one...",
     "share": "Share",
+    "show": "Show",
     "status": {
       "draft": "Draft",
       "ended": "Ended",

--- a/locales/en.json
+++ b/locales/en.json
@@ -325,15 +325,14 @@
     "selectedCount": "{n} response selected | {n} responses selected"
   },
   "calloutResponsesPage": {
-    "inlineAnswer": "Answer:",
     "moveToBucket": "Move to {bucket}",
-    "noAnswer": "None",
     "noTags": "No tags",
     "response": "Response",
     "responseNo": "Response {no}",
     "searchAssignee": "Assigned to...",
     "searchTag": "Tagged with...",
-    "showAnswer": "Show answer:",
+    "showAnswer": "Answer",
+    "showLatestComment": "Latest comment",
     "showingOf": "Showing {start} to {end} responses out of {total}"
   },
   "callouts": {
@@ -403,6 +402,7 @@
       "member": "Member",
       "superadmin": "Super Admin"
     },
+    "selectOne": "Select one...",
     "share": "Share",
     "status": {
       "draft": "Draft",

--- a/locales/en.json
+++ b/locales/en.json
@@ -293,6 +293,7 @@
       "updatedAt": "Date updated"
     },
     "dataGroup": {
+      "answers": "Questions",
       "response": "Response"
     }
   },
@@ -324,12 +325,15 @@
     "selectedCount": "{n} response selected | {n} responses selected"
   },
   "calloutResponsesPage": {
+    "inlineAnswer": "Answer:",
     "moveToBucket": "Move to {bucket}",
+    "noAnswer": "None",
     "noTags": "No tags",
     "response": "Response",
     "responseNo": "Response {no}",
     "searchAssignee": "Assigned to...",
     "searchTag": "Tagged with...",
+    "showAnswer": "Show answer:",
     "showingOf": "Showing {start} to {end} responses out of {total}"
   },
   "callouts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.0",
       "dependencies": {
         "@appsignal/javascript": "^1.3.24",
-        "@beabee/beabee-common": "^1.10.18",
+        "@beabee/beabee-common": "^1.10.21",
         "@fontsource/fira-sans": "^4.5.10",
         "@fontsource/fira-sans-condensed": "^4.5.10",
         "@fontsource/nunito-sans": "^4.5.10",
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@beabee/beabee-common": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.18.tgz",
-      "integrity": "sha512-dwxFCKUKQzrKX7Fcrz2SWglIlWYO0BwOfKi+YPD4Yd8RFY7NNfsOsOdkJ3cKupiMGvKLh+8N5aT3x3nKYVtyYg==",
+      "version": "1.10.21",
+      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.21.tgz",
+      "integrity": "sha512-x8+WzV7Bi3VMIXdsvCt5t4cum5cAJFaY0qVe+nxth9Repy7Qd3LfPHNLvt74KcLKP8rbPNP4dWrd12abT55xLw==",
       "dependencies": {
         "date-fns": "^2.29.3"
       }
@@ -6351,9 +6351,9 @@
       }
     },
     "@beabee/beabee-common": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.18.tgz",
-      "integrity": "sha512-dwxFCKUKQzrKX7Fcrz2SWglIlWYO0BwOfKi+YPD4Yd8RFY7NNfsOsOdkJ3cKupiMGvKLh+8N5aT3x3nKYVtyYg==",
+      "version": "1.10.21",
+      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-1.10.21.tgz",
+      "integrity": "sha512-x8+WzV7Bi3VMIXdsvCt5t4cum5cAJFaY0qVe+nxth9Repy7Qd3LfPHNLvt74KcLKP8rbPNP4dWrd12abT55xLw==",
       "requires": {
         "date-fns": "^2.29.3"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@appsignal/javascript": "^1.3.24",
-    "@beabee/beabee-common": "^1.10.18",
+    "@beabee/beabee-common": "^1.10.21",
     "@fontsource/fira-sans": "^4.5.10",
     "@fontsource/fira-sans-condensed": "^4.5.10",
     "@fontsource/nunito-sans": "^4.5.10",

--- a/src/components/forms/AppCheckbox.vue
+++ b/src/components/forms/AppCheckbox.vue
@@ -7,7 +7,10 @@
       :value="true"
       class="mt-1"
     />
-    <p v-if="label" class="ml-2 font-semibold">{{ label }}</p>
+    <p v-if="label || icon" class="ml-2 font-semibold">
+      <font-awesome-icon v-if="icon" :icon="icon" />
+      {{ label }}
+    </p>
   </label>
 </template>
 <script lang="ts" setup>
@@ -18,6 +21,7 @@ const props = defineProps<{
   modelValue: boolean;
   disabled?: boolean;
   label?: string;
+  icon?: string;
 }>();
 
 const modelValueProxy = computed({

--- a/src/components/forms/AppSelect.vue
+++ b/src/components/forms/AppSelect.vue
@@ -3,8 +3,13 @@
     <AppLabel v-if="label" :label="label" :required="required" />
     <select
       v-model="value"
-      class="w-full rounded border border-primary-40 bg-white p-2 leading-tight focus:shadow-input focus:outline-none"
-      :class="inputClass"
+      class="w-full rounded border p-2 leading-tight focus:shadow-input focus:outline-none"
+      :class="{
+        [inputClass || '']: true,
+        'cursor-not-allowed border-primary-20 bg-grey-lighter': disabled,
+        'border-primary-40 bg-white': !disabled,
+      }"
+      :disabled="disabled"
       :required="required"
     >
       <template v-for="item in items">
@@ -54,6 +59,7 @@ const props = defineProps<{
   label?: string;
   modelValue?: string | number | null;
   items: (SelectItem | SelectGroup)[];
+  disabled?: boolean;
   required?: boolean;
   inputClass?: string;
 }>();

--- a/src/components/pages/admin/callouts/SetAssigneeButton.vue
+++ b/src/components/pages/admin/callouts/SetAssigneeButton.vue
@@ -30,7 +30,7 @@ import AppSelectableList from '../../../AppSelectableList.vue';
 import AppDropdownButton from '../../../button/AppDropdownButton.vue';
 
 defineEmits<{ (event: 'assign', id: string | null): void }>();
-defineProps<{ currentAssigneeId: string | undefined; withText?: boolean }>();
+defineProps<{ currentAssigneeId?: string; withText?: boolean }>();
 
 const { t } = useI18n();
 

--- a/src/components/pages/callouts/steps/ContentStep.vue
+++ b/src/components/pages/callouts/steps/ContentStep.vue
@@ -183,7 +183,7 @@ onBeforeMount(() => {
   @apply font-body text-sm text-body !important;
 
   .formio-dialog-content {
-    @apply bg-grey-lighter !important;
+    @apply bg-white !important;
   }
 
   .nav {

--- a/src/components/search/AppSearch.vue
+++ b/src/components/search/AppSearch.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mb-4">
+  <div class="mb-8">
     <div class="mb-2 flex gap-2">
       <slot></slot>
       <AppButton

--- a/src/components/table/AppPaginatedTableResult.vue
+++ b/src/components/table/AppPaginatedTableResult.vue
@@ -17,7 +17,7 @@
       </i18n-t>
     </p>
 
-    <div class="flex gap-2">
+    <div v-if="!noLimit || totalPages > 1" class="flex gap-2">
       <template v-if="!noLimit">
         <p class="flex-1 self-center">
           <i18n-t v-if="result.count > 0" keypath="common.pageCount">
@@ -29,11 +29,7 @@
             >
           </i18n-t>
         </p>
-        <AppSelect
-          v-model="currentLimit"
-          :items="limits"
-          input-class="text-sm"
-        />
+        <AppSelect v-model="currentLimit" :items="limits" />
       </template>
       <AppPagination
         v-if="totalPages > 1"

--- a/src/components/table/AppTable.vue
+++ b/src/components/table/AppTable.vue
@@ -1,6 +1,6 @@
 <template>
-  <table class="">
-    <thead v-if="!hideHeaders" class="border-b border-primary-20 text-sm">
+  <table class="border-b border-primary-20">
+    <thead v-if="!hideHeaders" class="text-sm">
       <tr class="align-bottom">
         <th v-if="selectable" class="w-0 p-2">
           <AppCheckbox v-model="allSelected" class="h-5" />
@@ -46,26 +46,35 @@
         </td>
       </tr>
 
-      <tr
-        v-for="(item, i) in items"
-        :key="i"
-        class="border-b border-primary-20 align-top"
-        :class="rowClass(item)"
-      >
-        <td v-if="selectable" class="p-2">
-          <AppCheckbox v-model="item.selected" />
-        </td>
-        <td
-          v-for="(header, j) in headers"
-          :key="j"
-          class="p-2"
-          :align="header.align || undefined"
+      <template v-for="(item, i) in items" :key="i">
+        <tr
+          class="border-t border-primary-20 align-top"
+          :class="rowClass(item)"
         >
-          <slot :name="header.value" :item="item" :value="item[header.value]">{{
-            item[header.value]
-          }}</slot>
-        </td>
-      </tr>
+          <td v-if="selectable" class="p-2">
+            <AppCheckbox v-model="item.selected" />
+          </td>
+          <td
+            v-for="(header, j) in headers"
+            :key="j"
+            class="p-2"
+            :align="header.align || undefined"
+          >
+            <slot
+              :name="header.value"
+              :item="item"
+              :value="item[header.value]"
+              >{{ item[header.value] }}</slot
+            >
+          </td>
+        </tr>
+        <template v-if="hasSlotContent($slots.after, { item })">
+          <td v-if="selectable" />
+          <td class="p-2 pt-0" :colspan="headers.length">
+            <slot name="after" :item="item" />
+          </td>
+        </template>
+      </template>
     </tbody>
   </table>
 </template>
@@ -73,6 +82,7 @@
 <script lang="ts" setup>
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { hasSlotContent } from '../../utils';
 import AppCheckbox from '../forms/AppCheckbox.vue';
 import { Header, SortType } from './table.interface';
 

--- a/src/components/table/AppTable.vue
+++ b/src/components/table/AppTable.vue
@@ -66,12 +66,15 @@
             </slot>
           </td>
         </tr>
-        <template v-if="hasSlotContent($slots.after, { item })">
+        <tr
+          v-if="hasSlotContent($slots.after, { item })"
+          :class="rowClass(item)"
+        >
           <td v-if="selectable" />
           <td class="p-2 pt-0" :colspan="headers.length">
             <slot name="after" :item="item" />
           </td>
-        </template>
+        </tr>
       </template>
     </tbody>
   </table>

--- a/src/components/table/AppTable.vue
+++ b/src/components/table/AppTable.vue
@@ -31,17 +31,14 @@
     </thead>
 
     <tbody class="text-xs lg:text-sm">
-      <tr v-if="items === null">
+      <tr
+        v-if="!items || items.length === 0"
+        class="border-t border-primary-20"
+      >
+        <td v-if="selectable" />
         <td :colspan="headers.length" class="p-2">
-          <slot name="loading">
-            <p>{{ t('common.loading') }}</p>
-          </slot>
-        </td>
-      </tr>
-      <tr v-else-if="!items.length">
-        <td :colspan="headers.length" class="p-2">
-          <slot name="empty">
-            <p>{{ t('common.noResults') }}</p>
+          <slot :name="items ? 'empty' : 'loading'">
+            <p>{{ items ? t('common.noResults') : t('common.loading') }}</p>
           </slot>
         </td>
       </tr>

--- a/src/layouts/menu/TheMenuListItem.vue
+++ b/src/layouts/menu/TheMenuListItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    class="my-0.5 flex w-auto items-center justify-start rounded px-1 py-2 font-semibold md:w-12 md:justify-center md:overflow-x-hidden xl:w-auto xl:justify-start xl:overflow-auto"
-    :class="itemClass"
+    class="my-0.5 flex w-auto items-center justify-start rounded px-1 py-2 font-semibold text-body-80 md:w-12 md:justify-center md:overflow-x-hidden xl:w-auto xl:justify-start xl:overflow-auto"
+    :class="isActive ? 'bg-primary-20' : 'hover:bg-primary-5'"
   >
     <font-awesome-icon class="fa-fw inline-block h-4" :icon="icon" size="lg" />
 
@@ -10,30 +10,9 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue';
-
-const props = withDefaults(
-  defineProps<{
-    title: string;
-    icon: [string, string];
-    type?: 'main' | 'settings';
-    isActive?: boolean;
-  }>(),
-  {
-    type: 'main',
-  }
-);
-
-// Different nav item styles: tuple is [normal, active] classes
-const itemClasses = {
-  main: ['text-body-80 hover:bg-primary-5', 'text-body-80 bg-primary-20'],
-  settings: [
-    'text-grey-dark hover:bg-grey-lighter',
-    'bg-primary-5 text-grey-darker',
-  ],
-} as const;
-
-const itemClass = computed(
-  () => itemClasses[props.type][props.isActive ? 1 : 0]
-);
+defineProps<{
+  title: string;
+  icon: [string, string];
+  isActive?: boolean;
+}>();
 </script>

--- a/src/layouts/menu/TheMenuListSection.vue
+++ b/src/layouts/menu/TheMenuListSection.vue
@@ -1,8 +1,5 @@
 <template>
-  <nav
-    class="px-2 xl:px-4"
-    :class="section.type === 'main' ? 'text-body-80' : 'text-grey-dark'"
-  >
+  <nav class="px-2 text-body-80 xl:px-4">
     <div v-if="!isFirst" class="my-2 border-t border-primary-40" />
     <div v-if="section.title" class="pb-2 md:hidden xl:inline-block">
       {{ t(section.title) }}

--- a/src/layouts/menu/TheMenuListSection.vue
+++ b/src/layouts/menu/TheMenuListSection.vue
@@ -14,7 +14,6 @@
             <TheMenuListItem
               :icon="item.icon"
               :title="t(item.title)"
-              :type="section.type"
               :is-active="
                 item.isActive
                   ? item.isActive.test(route.path)

--- a/src/layouts/menu/menu-list.interface.ts
+++ b/src/layouts/menu/menu-list.interface.ts
@@ -1,6 +1,5 @@
 export interface MenuSection {
   title?: string;
-  type: 'main' | 'settings';
   items: MenuItem[];
 }
 

--- a/src/layouts/menu/menu-list.ts
+++ b/src/layouts/menu/menu-list.ts
@@ -6,7 +6,6 @@ export const menu = computed(
   () =>
     [
       {
-        type: 'main',
         items: [
           {
             title: 'menu.home',
@@ -22,7 +21,6 @@ export const menu = computed(
         ],
       },
       {
-        type: 'settings',
         items: [
           {
             title: 'menu.account',
@@ -45,7 +43,6 @@ export const menu = computed(
 
 export const adminMenu: MenuSection[] = [
   {
-    type: 'main',
     title: 'menu.admin',
     items: [
       {
@@ -74,7 +71,6 @@ export const adminMenu: MenuSection[] = [
     ],
   },
   {
-    type: 'settings',
     items: [
       {
         title: 'menu.membershipBuilder',

--- a/src/pages/admin/callouts/view/[id]/responses/index.vue
+++ b/src/pages/admin/callouts/view/[id]/responses/index.vue
@@ -88,7 +88,7 @@ meta:
           <ToggleTagButton
             :tag-items="tagItems"
             :selected-tags="selectedTags"
-            :manage-url="`${responsesUrl}/tags`"
+            :manage-url="`${route.path}/tags`"
             :loading="doingAction"
             :disabled="selectedCount === 0"
             @toggle="(tagId) => handleUpdateAction({ tags: [tagId] })"
@@ -127,7 +127,7 @@ meta:
       >
         <template #number="{ value, item }">
           <router-link
-            :to="`${responsesUrl}/${item.id}`"
+            :to="`${route.path}/${item.id}`"
             class="text-base font-bold text-link"
           >
             {{ t('calloutResponsesPage.responseNo', { no: n(value) }) }}
@@ -276,18 +276,10 @@ const selectedAssigneeId = computed(() => {
 const adminItems = ref<{ id: string; label: string }[]>([]);
 const tagItems = ref<{ id: string; label: string }[]>([]);
 
-const responsesUrl = computed(
-  () =>
-    router.resolve({
-      name: 'adminCalloutViewResponsesTable',
-      params: { id: props.callout.slug },
-    }).href
-);
-
 const bucketItems = computed(() =>
   buckets.value.map((bucket) => ({
     ...bucket,
-    to: responsesUrl.value + '?bucket=' + bucket.id,
+    to: `${route.path}?bucket=${bucket.id}`,
   }))
 );
 

--- a/src/pages/admin/callouts/view/[id]/responses/index.vue
+++ b/src/pages/admin/callouts/view/[id]/responses/index.vue
@@ -154,13 +154,15 @@ meta:
             :class="showLatestComment && item.latestComment ? 'mb-2' : ''"
           >
             <font-awesome-icon :icon="['fa', 'user-pen']" class="mr-2" />
-            <b>{{ t('calloutResponsesPage.inlineAnswer') }}</b>
-            {{
-              convertAnswer(
-                currentInlineComponent,
-                item.answers[currentInlineComponent.key]
-              )
-            }}
+            <b>{{ t('calloutResponsesPage.inlineAnswer') }}{{ ' ' }}</b>
+            <span class="italic">
+              {{
+                convertAnswer(
+                  currentInlineComponent,
+                  item.answers[currentInlineComponent.key]
+                )
+              }}
+            </span>
           </p>
           <div v-if="showLatestComment && item.latestComment">
             <font-awesome-icon :icon="['fa', 'comment']" class="mr-2" />
@@ -175,8 +177,11 @@ meta:
               }}
               •
             </span>
-            <b>{{ item.latestComment.contact.displayName }}: </b>
-            <span class="inline-block" v-html="item.latestComment.text"></span>
+            <b>{{ item.latestComment.contact.displayName }}:{{ ' ' }}</b>
+            <span
+              class="inline-block italic"
+              v-html="item.latestComment.text"
+            ></span>
           </div>
         </template>
       </AppPaginatedTable>

--- a/src/pages/admin/callouts/view/[id]/responses/index.vue
+++ b/src/pages/admin/callouts/view/[id]/responses/index.vue
@@ -76,6 +76,7 @@ meta:
             />
             <SetAssigneeButton
               :disabled="selectedCount === 0"
+              :loading="doingAction"
               :current-assignee-id="selectedAssigneeId"
               @assign="(assigneeId) => handleUpdateAction({ assigneeId })"
             />

--- a/src/pages/admin/callouts/view/[id]/responses/index.vue
+++ b/src/pages/admin/callouts/view/[id]/responses/index.vue
@@ -32,7 +32,7 @@ meta:
           ]"
         />
       </AppSearch>
-      <p class="text-sm font-semibold text-body-80">Show</p>
+      <p class="text-sm font-semibold text-body-80">{{ t('common.show') }}</p>
       <div class="mb-4 flex items-center gap-6 text-sm">
         <AppCheckbox
           v-model="showLatestComment"

--- a/src/pages/admin/callouts/view/[id]/responses/index.vue
+++ b/src/pages/admin/callouts/view/[id]/responses/index.vue
@@ -36,13 +36,13 @@ meta:
       <div class="mb-4 flex items-center gap-6 text-sm">
         <AppCheckbox
           v-model="showLatestComment"
-          label="Latest comment"
+          :label="t('calloutResponsesPage.showLatestComment')"
           icon="comment"
         />
         <div class="flex items-center gap-2">
           <AppCheckbox
             v-model="showInlineAnswer"
-            label="Answer"
+            :label="t('calloutResponsesPage.showAnswer')"
             icon="user-pen"
           />
           <AppSelect
@@ -50,12 +50,13 @@ meta:
             class="max-w-xs"
             :class="!showInlineAnswer && 'invisible'"
             :items="[
-              { id: '', label: t('calloutResponsesPage.noAnswer') },
+              { id: '', label: t('common.selectOne') },
               ...Object.entries(formFilterItems).map(([id, item]) => ({
                 id: id.substring(8),
                 label: item.label,
               })),
             ]"
+            required
           />
         </div>
       </div>
@@ -154,7 +155,7 @@ meta:
             :class="showLatestComment && item.latestComment ? 'mb-2' : ''"
           >
             <font-awesome-icon :icon="['fa', 'user-pen']" class="mr-2" />
-            <b>{{ t('calloutResponsesPage.inlineAnswer') }}{{ ' ' }}</b>
+            <b>{{ t('calloutResponsesPage.showAnswer') }}:{{ ' ' }}</b>
             <span class="italic">
               {{
                 convertAnswer(

--- a/src/pages/admin/callouts/view/[id]/responses/index.vue
+++ b/src/pages/admin/callouts/view/[id]/responses/index.vue
@@ -15,7 +15,6 @@ meta:
         v-model="currentRules"
         :filter-groups="filterGroupsWithQuestions"
         :filter-items="filterItemsWithExtras"
-        :expanded="showAdvancedSearch"
         @reset="currentRules = undefined"
       >
         <AppSelect
@@ -205,7 +204,6 @@ const responses = ref<
     }
   >
 >();
-const showAdvancedSearch = ref(false);
 const showLatestComment = ref(false);
 const doingAction = ref(false);
 

--- a/src/pages/callouts/index.vue
+++ b/src/pages/callouts/index.vue
@@ -22,7 +22,7 @@ meta:
       :placeholder="t('callouts.search')"
     />
     <div class="my-2 text-sm font-semibold uppercase text-primary-80 lg:my-0">
-      <span>{{ t('callouts.show') }}</span>
+      <span>{{ t('common.show') }}</span>
       <AppToggle
         v-model="currentShow"
         :items="[

--- a/src/plugins/icons.ts
+++ b/src/plugins/icons.ts
@@ -70,6 +70,8 @@ import {
   faFolder,
   faFilter,
   faDownload,
+  faComment,
+  faUserPen,
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(
@@ -130,6 +132,8 @@ library.add(
   faListOl,
   faHandsHelping,
   faChartLine,
+  faComment,
+  faUserPen,
   faWindowRestore,
   faSort,
   faPlus,

--- a/src/utils/api/api.interface.ts
+++ b/src/utils/api/api.interface.ts
@@ -370,6 +370,7 @@ export type GetCalloutResponseWith =
   | 'assignee'
   | 'callout'
   | 'contact'
+  | 'latestComment'
   | 'tags'
   | void;
 
@@ -379,6 +380,9 @@ export type GetCalloutResponseDataWith<With extends GetCalloutResponseWith> =
     ('assignee' extends With ? { assignee: GetContactData | null } : Noop) &
     ('callout' extends With ? { callout: GetCalloutData } : Noop) &
     ('contact' extends With ? { contact: GetContactData | null } : Noop) &
+    ('latestComment' extends With
+      ? { latestComment: GetCalloutResponseCommentData | null }
+      : Noop) &
     ('tags' extends With ? { tags: { id: string; name: string }[] } : Noop);
 
 export interface UpdateCalloutResponseCommentData {

--- a/src/utils/api/callout-response-comments.ts
+++ b/src/utils/api/callout-response-comments.ts
@@ -47,7 +47,7 @@ export async function updateCalloutResponseComment(
   return deserializeComment(data);
 }
 
-function deserializeComment(
+export function deserializeComment(
   comment: Serial<GetCalloutResponseCommentData>
 ): GetCalloutResponseCommentData {
   return {

--- a/src/utils/api/callout-response.ts
+++ b/src/utils/api/callout-response.ts
@@ -10,6 +10,7 @@ import {
   UpdateCalloutResponseData,
   GetCalloutResponseData,
 } from './api.interface';
+import { deserializeComment } from './callout-response-comments';
 
 // TODO: how to make this type safe?
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -22,6 +23,9 @@ export function deserializeCalloutResponse(response: any): any {
       assignee: deserializeContact(response.assignee),
     }),
     ...(response.contact && { contact: deserializeContact(response.contact) }),
+    ...(response.latestComment && {
+      latestComment: deserializeComment(response.latestComment),
+    }),
   };
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,7 +21,7 @@ module.exports = {
       white: shades('white'),
       black: shades('black'),
       grey: {
-        lighter: '#f6f6f6',
+        lighter: '#e5e5e5',
         light: '#c7c7c7',
         DEFAULT: '#a4a4a4',
         dark: '#5f5f5f',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,7 +21,7 @@ module.exports = {
       white: shades('white'),
       black: shades('black'),
       grey: {
-        lighter: '#e5e5e5',
+        lighter: '#eee',
         light: '#c7c7c7',
         DEFAULT: '#a4a4a4',
         dark: '#5f5f5f',


### PR DESCRIPTION
You can now show the latest comment and the answer to a question in the responses table, so you can scan for the most relevant responses.

### Screenshots

![image](https://user-images.githubusercontent.com/2084823/228611788-d7b8bb3f-21a3-4f95-a5e6-d0dde2644a69.png)

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `npm run check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [ ] Translations for all new i18n strings
