### PR TITLE
feat: add hover state for collapsed nav menu

### DIFF
--- a/src/layouts/menu/TheMenuListItem.vue
+++ b/src/layouts/menu/TheMenuListItem.vue
@@ -1,11 +1,19 @@
 <template>
   <div
-    class="my-0.5 flex w-auto items-center justify-start rounded px-1 py-2 font-semibold text-body-80 md:w-12 md:justify-center md:overflow-x-hidden xl:w-auto xl:justify-start xl:overflow-auto"
+    class="group relative my-0.5 flex w-auto items-center justify-start rounded px-1 py-2 font-semibold text-body-80 md:w-12 md:justify-center xl:w-auto xl:justify-start"
     :class="isActive ? 'bg-primary-20' : 'hover:bg-primary-5'"
   >
     <font-awesome-icon class="fa-fw inline-block h-4" :icon="icon" size="lg" />
 
     <span class="ml-2 md:hidden xl:inline-block">{{ title }}</span>
+    <span
+      class="absolute left-full hidden whitespace-nowrap rounded bg-black py-1 px-2 text-sm text-white md:max-xl:group-hover:block"
+    >
+      <span
+        class="absolute right-full top-1/2 h-0 w-0 -translate-y-1/2 border-y-4 border-r-4 border-y-white/0 border-r-black"
+      />
+      {{ title }}
+    </span>
   </div>
 </template>
 


### PR DESCRIPTION
Add a hover state for collapsed menu items so people can see what they are!

### Screenshots

![image](https://user-images.githubusercontent.com/2084823/228903556-8ebae3f4-b494-4404-90d4-a39d298650c5.png)

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `npm run check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
