### PR TITLE
feat: add new deployment workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: Check code
+name: Check
 
 on: [pull_request, workflow_call]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: ['main', 'dev', 'release']
+    branches: ['main', 'dev']
 
 jobs:
   init:
@@ -18,9 +18,6 @@ jobs:
               ;;
             refs/heads/dev)
               echo "stage=dev" >> $GITHUB_OUTPUT
-              ;;
-            refs/heads/release)
-              echo "stage=release" >> $GITHUB_OUTPUT
               ;;
           esac
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,8 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
     branches:
-      - 'feat*'
+      - 'feat/*'
 
 jobs:
   check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check]
 
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - 'feat*'
+
+jobs:
+  check:
+    uses: ./.github/workflows/check.yml
+
+  push:
+    runs-on: ubuntu-latest
+    needs: [check]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ secrets.DOCKER_ORGANISATION }}/frontend-test
+          tags: |
+            type=ref,event=tag
+            type=ref,event=branch
+            release
+
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            REVISION=${{ github.sha }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [push]
+    steps:
+      - uses: action/checkout@v3
+        with:
+          repository: beabee-communityrm/test-deploy
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - run: |
+          git config --global user.name "Deploy bot"
+          git config --global user.email "<>"
+
+          echo -n ${{ needs.push.outputs.version }} > FRONTEND_VERSION
+          ./update.sh
+
+          git add FRONTEND_VERSION docker-compose.yml
+          if ! git diff --quiet --cached; then
+            git commit -m "Deploy frontend ${{ needs.push.outputs.version }}"
+            git push
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    branches:
-      - 'feat/*'
+    tags:
+      - 'v/*'
 
 jobs:
   check:
@@ -22,10 +22,9 @@ jobs:
       - id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ secrets.DOCKER_ORGANISATION }}/frontend-test
+          images: ${{ secrets.DOCKER_ORGANISATION }}/frontend
           tags: |
             type=ref,event=tag
-            type=ref,event=branch
             release
 
       - uses: docker/login-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [push]
     steps:
-      - uses: action/checkout@v3
+      - uses: actions/checkout@v3
         with:
           repository: beabee-communityrm/test-deploy
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v/*'
+      - 'v*'
 
 jobs:
   check:


### PR DESCRIPTION
This PR adds version tagging to Docker images. Any Git tags which match v* will now create an equivalent tag in Docker, the release Docker tag will continue to be updated.

It also triggers hive deployment by pushing an updated docker-compose.yml file (with latest tags) to a repo, which our Portainer instance polls then updates the stack. This is currently being tested (hence the repo is called test-deploy)
