### PR TITLE
build: only run commands if needed and make them quicker

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,14 @@
 #!/bin/sh
 
-cd /usr/share/nginx/html
+if [ ! -f /.installed ]; then
+  touch /.installed
 
-find -type f -exec sed -i s#__appUrl__#$APP_BASE_URL#g {} +
-find -type f -exec sed -i s#__apiUrl__#$API_BASE_URL#g {} +
-find -type f -exec sed -i s#__revision__#$APP_REVISION#g {} +
-find -type f -exec sed -i s#__appsignalKey__#$APPSIGNAL_KEY#g {} +
-find -type f -exec sed -i s#__cnrMode__#$CNR_MODE#g {} +
+  find /usr/share/nginx/html -type f -name '*.js' -exec \
+    sed -i \
+      -e s#__appUrl__#$APP_BASE_URL#g \
+      -e s#__apiUrl__#$API_BASE_URL#g \
+      -e s#__revision__#$APP_REVISION#g \
+      -e s#__appsignalKey__#$APPSIGNAL_KEY#g \
+      -e s#__cnrMode__#$CNR_MODE#g \
+    {} +
+fi


### PR DESCRIPTION
Fixes a problem where the `sed` commands were taking a long time, this should make the entrypoint script much leaner by only doing the substitutions once and only applying them to JS files
