### PR TITLE
style: Same UI for tag/role editor

### DIFF
--- a/src/components/tag/TagEditorItem.vue
+++ b/src/components/tag/TagEditorItem.vue
@@ -6,18 +6,17 @@
       </strong>
       <AppButtonGroup class="ml-auto">
         <AppButton
-          :icon="faPencil"
           size="sm"
-          variant="primaryOutlined"
+          variant="text"
           @click="formVisible = !formVisible"
-          >{{
-        }}</AppButton>
+          >{{ t('actions.edit') }}</AppButton
+        >
         <AppButton
-          variant="danger"
           size="sm"
-          :icon="faTrash"
+          variant="dangerText"
           @click="showDeleteModal = true"
         >
+          {{ t('actions.delete') }}
         </AppButton>
       </AppButtonGroup>
     </div>

--- a/src/components/tag/TagEditorItem.vue
+++ b/src/components/tag/TagEditorItem.vue
@@ -42,7 +42,7 @@
   </div>
 </template>
 <script lang="ts" setup>
-import { faPencil, faTag, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faTag } from '@fortawesome/free-solid-svg-icons';
 import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import {


### PR DESCRIPTION
## Style: Consolidate tag and role editor UI

Updated tag editor UI to match the existing role editor.
Edit and delete buttons are now textual.

![image](https://github.com/beabee-communityrm/beabee-frontend/assets/122730/1d69d2e1-39e9-4341-973a-58590b47447f)
![image](https://github.com/beabee-communityrm/beabee-frontend/assets/122730/b48baf5c-47fd-429d-9e86-3f5cf064a455)

