### PR TITLE
feat: add newsletter status toggle for admins

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -5,6 +5,9 @@
     "deliveryAddress": "Adresse",
     "deliveryOptIn": "Postsendung",
     "loginDetail": "Anmeldedaten",
+    "newsletter": {
+      "currentStatus": {}
+    },
     "savedPassword": "Das neue Passwort wurde gespeichert.",
     "subTitle": "Alle benötigten Felder sind mit * markiert. Alle Informationen werden vertraulich behandelt.",
     "title": "Account"

--- a/locales/de.json
+++ b/locales/de.json
@@ -6,7 +6,17 @@
     "deliveryOptIn": "Postsendung",
     "loginDetail": "Anmeldedaten",
     "newsletter": {
-      "currentStatus": {}
+      "cantUpdate": "Um den Newsletter-Status dieses Kontakts zu ändern, wende dich bitte an support{'@'}beabee.io.",
+      "currentStatus": {
+        "cleaned": "Dieser Kontakt wurde aus deiner Newsletter-Liste entfernt, die E-Mail-Adresse hat wahrscheinlich gebounct.",
+        "none": "Dieser Kontakt ist nicht für deine Newsletterliste angemeldet.",
+        "pending": "Dieser Kontakt hat ein Opt-in für Ihre Newsletter-Liste erhalten, das er akzeptieren muss, um sich anzumelden.",
+        "subscribed": "Dieser Kontakt ist für deine Newsletterliste angemeldet.",
+        "unsubscribed": "Dieser Kontakt ist nicht für deine Newsletterliste angemeldet."
+      },
+      "subscribe": "Für den Newsletter anmelden",
+      "title": "Newsletter",
+      "unsubscribe": "Vom Newsletter abmelden"
     },
     "savedPassword": "Das neue Passwort wurde gespeichert.",
     "subTitle": "Alle benötigten Felder sind mit * markiert. Alle Informationen werden vertraulich behandelt.",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -6,7 +6,17 @@
     "deliveryOptIn": "Postsendung",
     "loginDetail": "Anmeldedaten",
     "newsletter": {
-      "currentStatus": {}
+      "cantUpdate": "Um den Newsletter-Status dieses Kontakts zu ändern, wende dich bitte an support{'@'}beabee.io.",
+      "currentStatus": {
+        "cleaned": "Dieser Kontakt wurde aus deiner Newsletter-Liste entfernt, die E-Mail-Adresse hat wahrscheinlich gebounct.",
+        "none": "Dieser Kontakt ist nicht für deine Newsletterliste angemeldet.",
+        "pending": "Dieser Kontakt hat ein Opt-in für Ihre Newsletter-Liste erhalten, das er akzeptieren muss, um sich anzumelden.",
+        "subscribed": "Dieser Kontakt ist für deine Newsletterliste angemeldet.",
+        "unsubscribed": "Dieser Kontakt ist nicht für deine Newsletterliste angemeldet."
+      },
+      "subscribe": "Für den Newsletter anmelden",
+      "title": "Newsletter",
+      "unsubscribe": "Vom Newsletter abmelden"
     },
     "savedPassword": "Das neue Passwort wurde gespeichert. ",
     "subTitle": "Alle benötigten Felder sind mit * markiert. Alle Informationen werden vertraulich behandelt.",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -5,6 +5,9 @@
     "deliveryAddress": "Adresse",
     "deliveryOptIn": "Postsendung",
     "loginDetail": "Anmeldedaten",
+    "newsletter": {
+      "currentStatus": {}
+    },
     "savedPassword": "Das neue Passwort wurde gespeichert. ",
     "subTitle": "Alle benötigten Felder sind mit * markiert. Alle Informationen werden vertraulich behandelt.",
     "title": "Account"

--- a/locales/en.json
+++ b/locales/en.json
@@ -5,6 +5,19 @@
     "deliveryAddress": "Delivery address",
     "deliveryOptIn": "Delivery opt-in",
     "loginDetail": "Login details",
+    "newsletter": {
+      "cantUpdate": "To change this contact's newsletter status, please contact support{'@'}beabee.io.",
+      "currentStatus": {
+        "cleaned": "This contact has been cleaned from your newsletter list, their email address is probably bouncing.",
+        "none": "This contact isn't subscribed to your newsletter list.",
+        "pending": "This contact has been sent an opt-in for your newsletter list, they must accept it to become subscribed.",
+        "subscribed": "This contact is subscribed to your newsletter list.",
+        "unsubscribed": "This contact isn't subscribed to your newsletter list."
+      },
+      "subscribe": "Subscribe them to the newsletter",
+      "title": "Newsletter",
+      "unsubscribe": "Unsubscribe them from the newsletter"
+    },
     "savedPassword": "New password saved",
     "subTitle": "Required fields are marked with an asterisk. All information submitted here is private.",
     "title": "Account"
@@ -17,6 +30,7 @@
     "continue": "Continue",
     "delete": "Delete",
     "edit": "Edit",
+    "endnow": "End now",
     "export": "Export",
     "noBack": "No, go back",
     "participate": "Participate",
@@ -263,6 +277,7 @@
   },
   "calloutAdmin": {
     "deleted": "Callout deleted.",
+    "ended": "Callout ended. You can reopen it by editing it.",
     "overview": "Overview",
     "responses": "Responses"
   },

--- a/src/components/contact/ContactUpdateAccount.vue
+++ b/src/components/contact/ContactUpdateAccount.vue
@@ -1,6 +1,6 @@
 <template>
   <AppForm
-    :button-text="t('form.saveChanges')"
+    :button-text="t('actions.update')"
     :success-text="t('form.saved')"
     @submit="handleSubmit"
   >
@@ -14,6 +14,38 @@
       v-model:lastName="data.lastName"
       :optional-names="isAdmin"
     />
+
+    <template v-if="accountContent.showNewsletterOptIn && isAdmin">
+      <AppHeading class="mt-6 mb-2">
+        {{ t('accountPage.newsletter.title') }}
+      </AppHeading>
+
+      <p class="mb-4">
+        {{
+          t('accountPage.newsletter.currentStatus.' + currentNewsletterStatus)
+        }}
+      </p>
+
+      <AppNotification
+        v-if="
+          currentNewsletterStatus === NewsletterStatus.Cleaned ||
+          currentNewsletterStatus === NewsletterStatus.Pending
+        "
+        variant="warning"
+        :title="t('accountPage.newsletter.cantUpdate')"
+      />
+      <AppCheckbox
+        v-else-if="currentNewsletterStatus === NewsletterStatus.Subscribed"
+        v-model="data.newsletterToggle"
+        :label="t('accountPage.newsletter.unsubscribe')"
+      />
+      <AppCheckbox
+        v-else
+        v-model="data.newsletterToggle"
+        :label="t('accountPage.newsletter.subscribe')"
+        class="mb-4"
+      />
+    </template>
 
     <AppHeading class="mt-6 mb-2">
       {{ t('accountPage.deliveryAddress') }}
@@ -49,7 +81,8 @@
   </AppForm>
 </template>
 <script lang="ts" setup>
-import { computed, reactive, toRef, watch } from 'vue';
+import { NewsletterStatus } from '@beabee/beabee-common';
+import { computed, reactive, ref, toRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import AppAddress from '../AppAddress.vue';
 import ContactBasicFields from './ContactBasicFields.vue';
@@ -59,6 +92,8 @@ import { fetchContent } from '../../utils/api/content';
 import { fetchContact, updateContact } from '../../utils/api/contact';
 import AppRadioGroup from '../forms/AppRadioGroup.vue';
 import AppForm from '../forms/AppForm.vue';
+import AppNotification from '../AppNotification.vue';
+import AppCheckbox from '../forms/AppCheckbox.vue';
 
 const props = defineProps<{
   id: string;
@@ -70,10 +105,13 @@ const isAdmin = computed(() => props.id !== 'me');
 
 const accountContent = await fetchContent('join/setup');
 
+const currentNewsletterStatus = ref(NewsletterStatus.None);
+
 const data = reactive({
   emailAddress: '',
   firstName: '',
   lastName: '',
+  newsletterToggle: false,
   deliveryOptIn: false,
   addressLine1: '',
   addressLine2: '' as string | undefined,
@@ -89,7 +127,10 @@ watch(
     data.emailAddress = contact.email;
     data.firstName = contact.firstname;
     data.lastName = contact.lastname;
+    data.newsletterToggle = false;
     data.deliveryOptIn = contact.profile.deliveryOptIn;
+
+    currentNewsletterStatus.value = contact.profile.newsletterStatus;
 
     const address = contact.profile.deliveryAddress;
     data.addressLine1 = address?.line1 || '';
@@ -101,11 +142,22 @@ watch(
 );
 
 async function handleSubmit() {
+  const newNewsletterStatus =
+    data.newsletterToggle &&
+    (currentNewsletterStatus.value === NewsletterStatus.Subscribed
+      ? NewsletterStatus.Unsubscribed
+      : NewsletterStatus.Subscribed);
+
   await updateContact(props.id, {
     email: data.emailAddress,
     firstname: data.firstName,
     lastname: data.lastName,
     profile: {
+      // Only update newsletter status if the checkbox was ticked
+      ...(newNewsletterStatus && {
+        newsletterStatus: newNewsletterStatus,
+      }),
+      // Only update opt in if it's visible
       ...(accountContent.showMailOptIn && {
         deliveryOptIn: data.deliveryOptIn,
       }),
@@ -117,5 +169,10 @@ async function handleSubmit() {
       },
     },
   });
+
+  if (newNewsletterStatus) {
+    currentNewsletterStatus.value = newNewsletterStatus;
+    data.newsletterToggle = false;
+  }
 }
 </script>

--- a/src/pages/admin/contacts/[id]/index.vue
+++ b/src/pages/admin/contacts/[id]/index.vue
@@ -45,7 +45,9 @@ meta:
         />
         <AppInfoListItem
           :name="t('contactOverview.newsletter')"
-          :value="contact.profile.newsletterStatus"
+          :value="
+            t('common.newsletterStatus.' + contact.profile.newsletterStatus)
+          "
         />
         <AppInfoListItem
           :name="t('contacts.data.groups')"


### PR DESCRIPTION
Add a simple way for admins to switch a contact's newsletter status between subscribed and unsubscribed. This solves an immediate need but needs a lot of improvement, e.g. fixing pending/cleaned users, but it mostly relies on the newsletter integration being better.

### Screenshots

![image](https://github.com/beabee-communityrm/beabee-frontend/assets/2084823/f8db2f56-6c98-479b-990f-3e5331ec930e)

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `npm run check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
