### PR TITLE
fix: initialise default theme

### DIFF
--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -125,5 +125,6 @@ watch(
   },
   {
     deep: true,
+    immediate: true, // Initialise default theme on page load
   }
 );


### PR DESCRIPTION
Initialise a default theme so even if the initial API request (for /content/general) fails then there are still some colours.

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `npm run check` and addressed any problems
- [x] PR doesn't have merge conflicts
