### PR TITLE
feat: add callout response guest fields

### DIFF
--- a/src/pages/admin/callouts/view/[id]/responses/[rid].vue
+++ b/src/pages/admin/callouts/view/[id]/responses/[rid].vue
@@ -45,6 +45,11 @@ meta:
     <AppHeading class="mb-4">
       {{ t('calloutResponsesPage.responseNo', { no: n(response.number) }) }}
     </AppHeading>
+    <p v-if="response.tags.length > 0" class="mb-4">
+      <font-awesome-icon :icon="faTag" class="mr-2" />
+      <AppTag v-for="tag in response.tags" :key="tag.id" :tag="tag.name" />
+    </p>
+
     <AppInfoList class="mb-4">
       <AppInfoListItem :name="t('calloutResponse.data.contact')">
         <router-link
@@ -64,13 +69,6 @@ meta:
         :name="t('calloutResponse.data.createdAt')"
         :value="formatLocale(response.createdAt, 'Pp')"
       />
-      <AppInfoListItem
-        :name="t('calloutResponse.data.bucket')"
-        :value="bucketName"
-      />
-      <AppInfoListItem :name="t('calloutResponse.data.tags')">
-        <AppTag v-for="tag in response.tags" :key="tag.id" :tag="tag.name" />
-      </AppInfoListItem>
       <AppInfoListItem :name="t('calloutResponse.data.assignee')">
         <router-link
           v-if="response.assignee"
@@ -175,6 +173,8 @@ import {
   faCaretLeft,
   faCaretRight,
   faPen,
+  faTag,
+  faUser,
 } from '@fortawesome/free-solid-svg-icons';
 import { addNotification } from '../../../../../../store/notifications';
 import AppNotification from '../../../../../../components/AppNotification.vue';

--- a/src/pages/admin/callouts/view/[id]/responses/[rid].vue
+++ b/src/pages/admin/callouts/view/[id]/responses/[rid].vue
@@ -52,8 +52,13 @@ meta:
           :to="`/admin/contacts/${response.contact.id}`"
           class="text-link"
         >
-          {{ response.contact.displayName }}
+          <font-awesome-icon :icon="faUser" class="mr-2" />{{
+            response.contact.displayName
+          }}
         </router-link>
+        <span v-else-if="response.guestName">
+          {{ response.guestName }} ({{ response.guestEmail }})
+        </span>
       </AppInfoListItem>
       <AppInfoListItem
         :name="t('calloutResponse.data.createdAt')"

--- a/src/pages/admin/callouts/view/[id]/responses/[rid].vue
+++ b/src/pages/admin/callouts/view/[id]/responses/[rid].vue
@@ -193,6 +193,10 @@ addBreadcrumb(
       to: `/admin/callouts/view/${props.callout.slug}/responses`,
     },
     {
+      title: bucketName.value,
+      to: `/admin/callouts/view/${props.callout.slug}/responses?bucket=${response.value?.bucket}`,
+    },
+    {
       title: t('calloutResponsesPage.responseNo', {
         no: response.value?.number ? n(response.value?.number) : '?',
       }),

--- a/src/pages/admin/callouts/view/[id]/responses/index.vue
+++ b/src/pages/admin/callouts/view/[id]/responses/index.vue
@@ -396,6 +396,11 @@ addBreadcrumb(
       title: t('calloutAdmin.responses'),
       to: `/admin/callouts/view/${props.callout.slug}/responses`,
     },
+    {
+      title:
+        bucketItems.value.find((b) => b.id === currentBucket.value)?.label ||
+        '',
+    },
   ])
 );
 

--- a/src/pages/admin/callouts/view/[id]/responses/index.vue
+++ b/src/pages/admin/callouts/view/[id]/responses/index.vue
@@ -135,14 +135,19 @@ meta:
           </router-link>
           <span v-else>-</span>
         </template>
-        <template #value-contact="{ value }">
+        <template #value-contact="{ value, item }">
           <router-link
             v-if="value"
             :to="`/admin/contacts/${value.id}`"
             class="text-link"
           >
-            {{ value.displayName }}
+            <font-awesome-icon :icon="faUser" class="mr-2" />{{
+              value.displayName
+            }}
           </router-link>
+          <span v-else-if="item.guestName">
+            {{ item.guestName }} ({{ item.guestEmail }})
+          </span>
           <span v-else>-</span>
         </template>
         <template #value-createdAt="{ value }">
@@ -250,6 +255,7 @@ import {
   faComment,
   faDownload,
   faTag,
+  faUser,
   faUserPen,
 } from '@fortawesome/free-solid-svg-icons';
 import { addNotification } from '../../../../../../store/notifications';

--- a/src/utils/api/api.interface.ts
+++ b/src/utils/api/api.interface.ts
@@ -353,6 +353,8 @@ export interface GetCalloutResponseData {
   createdAt: Date;
   updatedAt: Date;
   bucket: string;
+  guestName: string | null;
+  guestEmail: string | null;
 }
 
 export interface CreateCalloutResponseData {


### PR DESCRIPTION
Added the guest name/email to the callout response page.

Also added the bucket to the breadcrumb (for easier navigability) and cleaned up the response info list.

### Screenshots

![image](https://github.com/beabee-communityrm/beabee-frontend/assets/2084823/98639418-2730-4c57-ad95-8ee67494c478)

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `npm run check` and addressed any problems
- [x] PR doesn't have merge conflicts