### PR TITLE
fix: replicate callout button not working

### DIFF
--- a/src/pages/admin/callouts/view/[id]/index.vue
+++ b/src/pages/admin/callouts/view/[id]/index.vue
@@ -173,10 +173,13 @@ async function replicateThisCallout() {
     ...props.callout,
     slug: props.callout.slug + '-copy',
     title: props.callout.title + ' copy',
-    status: undefined,
     starts: null,
     expires: null,
+    // TODO: Remove these extra properties, should be handled elsewhere
+    status: undefined,
+    responseCount: undefined,
   };
+
   const newCallout = await createCallout(newCalloutData);
   router.push({
     path: '/admin/callouts/edit/' + newCallout.slug,


### PR DESCRIPTION
The API request fails because there is a `responseCount` in the payload, this is a quick fix to remove it. We need a longer term solution for this as it's not caught by the type checker.