### PR TITLE
chore: update payment conversion flow text

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -533,7 +533,7 @@
       "joined": "Kontakt seit",
       "lastSeen": "Zuletzt angemeldet",
       "lastname": "Nachname",
-      "manualPaymentSource": "Manuelles Zahlungsquelle",
+      "manualPaymentSource": "Manuelle Zahlungsquelle",
       "membershipExpires": "Mitglied bis",
       "membershipStarts": "Mitglied seit",
       "name": "Name",
@@ -575,7 +575,8 @@
     "expired": "Ihre Mitgliedschaft ist ausgelaufen.",
     "expiredText": "Möchten Sie Ihre Mitgliedschaft verlängern? Selbst kleinste Beträge helfen uns und unserer Arbeit. Danke!",
     "hasPendingPayment": "Ihre Zahlung wird gerade verarbeitet.",
-    "manualPayment": "Sie leisten Ihren Beitrag aktuell via {source}. Richten Sie hier jetzt eine automatische Abbuchung via Lastschrift oder Kreditkarte ein. Dann wird es für Sie leichter, Ihre Beiträge zu verwalten. Und wir bekommen einen besseren Überblick, auf welche Beiträge wir uns monatlich verlassen können.",
+    "manualPayment": "Sie zahlen Ihren Beitrag aktuell via {source}. Indem Sie über unser Mitgliedersystem bezahlen, bekommen wir einen besseren Überblick, auf welche Beiträge wir uns monatlich verlassen können. Für Sie wird es außerdem einfacher, Ihren Beitrag jederzeit zu ändern.",
+    "manualPaymentSource": "einem Drittanbieter",
     "nextAmountChanging": "Ab dem {renewalDate} zahlen Sie {nextAmount}.",
     "paymentHistory": {
       "empty": "Ältere Zahlungen und Rechnungen finden Sie hier.",

--- a/locales/de.json
+++ b/locales/de.json
@@ -575,7 +575,7 @@
     "expired": "Ihre Mitgliedschaft ist ausgelaufen.",
     "expiredText": "Möchten Sie Ihre Mitgliedschaft verlängern? Selbst kleinste Beträge helfen uns und unserer Arbeit. Danke!",
     "hasPendingPayment": "Ihre Zahlung wird gerade verarbeitet.",
-    "manualPayment": "Sie leisten Ihren Beitrag aktuell manuell via Banküberweisung. Richten Sie hier jetzt eine automatische Abbuchung via Lastschrift ein. Dann wird es für Sie leichter, Ihre Beiträge zu verwalten. Und wir bekommen einen besseren Überblick, auf welche Beiträge wir uns monatlich verlassen können.",
+    "manualPayment": "Sie leisten Ihren Beitrag aktuell via {source}. Richten Sie hier jetzt eine automatische Abbuchung via Lastschrift oder Kreditkarte ein. Dann wird es für Sie leichter, Ihre Beiträge zu verwalten. Und wir bekommen einen besseren Überblick, auf welche Beiträge wir uns monatlich verlassen können.",
     "nextAmountChanging": "Ab dem {renewalDate} zahlen Sie {nextAmount}.",
     "paymentHistory": {
       "empty": "Ältere Zahlungen und Rechnungen finden Sie hier.",
@@ -593,7 +593,7 @@
     "startContribution": "Mitgliedschaft beginnen",
     "startedContribution": "Ihre Mitgliedschaft hat begonnen.",
     "updateContribution": "Beitrag aktualisieren",
-    "updatePaymentType": "Neuen Zahlungsweg einrichten",
+    "updatePaymentType": "Neue Zahlungsmethode einrichten",
     "updatedContribution": "Ihr Beitrag wurde geändert.",
     "updatedPaymentSource": "Ihre Zahlungsart wurde aktualisiert.",
     "willExpire": "Ihre Mitgliedschaft läuft in {expires} ab.",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -575,7 +575,8 @@
     "expired": "Deine Mitgliedschaft ist ausgelaufen.",
     "expiredText": "Möchtest Du deine Mitgliedschaft verlängern? Selbst kleinste Beträge helfen uns und unserer Arbeit. Danke!",
     "hasPendingPayment": "Deine Zahlung wird gerade verarbeitet.",
-    "manualPayment": "Du leistest deinen Beitrag aktuell manuell via Banküberweisung, einen Drittanbieter o.ä.. Richte hier jetzt eine automatische Abbuchung via Lastschrift oder Kreditkarte ein. Dann wird es für dich leichter, deine Beiträge zu verwalten. Und wir bekommen einen besseren Überblick, auf welche Beiträge wir uns monatlich verlassen können.",
+    "manualPayment": "Du zahlst deinen Beitrag aktuell via {source}. Indem du über unser Mitgliedersystem bezahlst, bekommen wir einen besseren Überblick, auf welche Beiträge wir uns monatlich verlassen können. Für dich wird es außerdem einfacher, deinen Beitrag jederzeit zu ändern.",
+    "manualPaymentSource": "einem Drittanbieter",
     "nextAmountChanging": "Ab dem {renewalDate} zahlst Du {nextAmount}.",
     "paymentHistory": {
       "empty": "Ältere Zahlungen und Rechnungen finden Sie hier.",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -575,7 +575,7 @@
     "expired": "Deine Mitgliedschaft ist ausgelaufen.",
     "expiredText": "Möchtest Du deine Mitgliedschaft verlängern? Selbst kleinste Beträge helfen uns und unserer Arbeit. Danke!",
     "hasPendingPayment": "Deine Zahlung wird gerade verarbeitet.",
-    "manualPayment": "Du leistest deinen Beitrag aktuell manuell via Banküberweisung. Richte hier jetzt eine automatische Abbuchung via Lastschrift ein. Dann wird es für dich leichter, deine Beiträge zu verwalten. Und wir bekommen einen besseren Überblick, auf welche Beiträge wir uns monatlich verlassen können.",
+    "manualPayment": "Du leistest deinen Beitrag aktuell manuell via Banküberweisung, einen Drittanbieter o.ä.. Richte hier jetzt eine automatische Abbuchung via Lastschrift oder Kreditkarte ein. Dann wird es für dich leichter, deine Beiträge zu verwalten. Und wir bekommen einen besseren Überblick, auf welche Beiträge wir uns monatlich verlassen können.",
     "nextAmountChanging": "Ab dem {renewalDate} zahlst Du {nextAmount}.",
     "paymentHistory": {
       "empty": "Ältere Zahlungen und Rechnungen finden Sie hier.",
@@ -593,7 +593,7 @@
     "startContribution": "Mitgliedschaft beginnen",
     "startedContribution": "Deine Mitgliedschaft hat begonnen.",
     "updateContribution": "Beitrag aktualisieren",
-    "updatePaymentType": "Neuen Zahlungsweg einrichten",
+    "updatePaymentType": "Neue Zahlungsmethode einrichten",
     "updatedContribution": "Dein Beitrag wurde geändert.",
     "updatedPaymentSource": "Deine Zahlungsart wurde aktualisiert. ",
     "willExpire": "Deine Mitgliedschaft läuft in {expires} ab.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -533,7 +533,7 @@
       "joined": "Joined",
       "lastSeen": "Last seen",
       "lastname": "Last name",
-      "manualPaymentSource": "Manuelles Zahlungsquelle",
+      "manualPaymentSource": "Manual payment source",
       "membershipExpires": "Member until",
       "membershipStarts": "Member since",
       "name": "Name",

--- a/locales/en.json
+++ b/locales/en.json
@@ -575,7 +575,8 @@
     "expired": "Your contribution expired.",
     "expiredText": "Please consider renewing, even if at the lowest amount it would help us immensely. Thank you!",
     "hasPendingPayment": "Your payment is currently being processed.",
-    "manualPayment": "You are paying manually through bank transfer right now. To make it easier for you to manage your contribution and easier for us to know on how much money from our members we can rely on month on month, please update to paying automatically via direct debit.",
+    "manualPayment": "You are currently paying your membership fee via {source}. By paying through our membership system you'll help us to know how much money from our members we can rely on month on month and it'll be easier for you to manage your contribution.",
+    "manualPaymentSource": "a third party tool",
     "nextAmountChanging": "Your contribution will change to {nextAmount} on {renewalDate}.",
     "paymentHistory": {
       "empty": "Past payments and their invoices will show up here.",
@@ -593,7 +594,7 @@
     "startContribution": "Start contribution",
     "startedContribution": "Your contribution has started.",
     "updateContribution": "Update contribution",
-    "updatePaymentType": "Update payment type",
+    "updatePaymentType": "Update payment method",
     "updatedContribution": "Your contribution has been updated.",
     "updatedPaymentSource": "Your payment method has been updated.",
     "willExpire": "Your contribution will expire in {expires}.",

--- a/src/components/pages/profile/contribution/UpdateContribution.vue
+++ b/src/components/pages/profile/contribution/UpdateContribution.vue
@@ -6,7 +6,14 @@
       </AppHeading>
 
       <p v-if="isManualActiveMember" class="mb-4">
-        {{ t('contribution.manualPayment') }}
+        {{
+          t('contribution.manualPayment', {
+            source:
+              (modelValue.paymentSource?.method === null &&
+                modelValue.paymentSource.source) ||
+              t('contribution.manualPaymentSource'),
+          })
+        }}
       </p>
 
       <AppNotification


### PR DESCRIPTION
Improved the text we should users when they are switching from a manual to automatic contribution

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `npm run check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
