### PR TITLE
feat: add authenticated file upload

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -819,6 +819,7 @@
         "email": "Ungültige E-Mail-Adresse",
         "required": "E-Mail-Adresse benötigt"
       },
+      "file": {},
       "firstName": {
         "required": "Vorname benötigt"
       },
@@ -870,7 +871,6 @@
     "saved": "Gespeichert!",
     "unsavedChanges": "Ungespeicherte Änderungen",
     "updated": "Aktualisiert",
-    "uploading": "Es wird hochgeladen",
     "warning": "Ändere hier nur etwas, wenn du das Einverständnis hast. Änderungen werden auch den Nutzern angezeigt."
   },
   "homePage": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -273,6 +273,7 @@
     "joinNow": "Mitglied werden",
     "loginToYourAccount": "Einloggen",
     "membersOnly": "An diesem Callout können nur zahlende Mitglieder teilnehmen. Um teilzunehmen",
+    "responseSubmitted": "Antwort eingereicht",
     "share": {
       "address": "Diesen Callout per Link teilen:",
       "services": "Diesen Callout auf einer der folgenden Plattformen teilen: "
@@ -823,7 +824,10 @@
         "email": "Ungültige E-Mail-Adresse",
         "required": "E-Mail-Adresse benötigt"
       },
-      "file": {},
+      "file": {
+        "rateLimited": "Hochladen fehlgeschlagen: Sie haben in zu kurzer Zeit zu viele Dateien hochgeladen. Bitte warten Sie ein paar Minuten, bevor Sie es erneut versuchen.",
+        "tooBig": "Hochladen fehlgeschlagen: Die Dateigröße darf max. 20 MB betragen."
+      },
       "firstName": {
         "required": "Vorname benötigt"
       },

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -819,6 +819,7 @@
         "email": "Ungültige E-Mail-Adresse",
         "required": "E-Mail-Adresse benötigt"
       },
+      "file": {},
       "firstName": {
         "required": "Vorname benötigt"
       },
@@ -870,7 +871,6 @@
     "saved": "Gespeichert!",
     "unsavedChanges": "Ungespeicherte Änderungen",
     "updated": "Aktualisiert",
-    "uploading": "Es wird hochgeladen",
     "warning": "Ändere hier nur etwas, wenn du das Einverständnis hast. Änderungen werden auch den Nutzern angezeigt."
   },
   "homePage": {

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -273,6 +273,7 @@
     "joinNow": "Mitglied werden",
     "loginToYourAccount": "Einloggen",
     "membersOnly": "An diesem Callout können nur zahlende Mitglieder teilnehmen. Um teilzunehmen",
+    "responseSubmitted": "Antwort eingereicht",
     "share": {
       "address": "Diesen Callout per Link teilen:",
       "services": "Diesen Callout auf einer der folgenden Plattformen teilen: "
@@ -823,7 +824,10 @@
         "email": "Ungültige E-Mail-Adresse",
         "required": "E-Mail-Adresse benötigt"
       },
-      "file": {},
+      "file": {
+        "rateLimited": "Hochladen fehlgeschlagen: Du hast in zu kurzer Zeit zu viele Dateien hochgeladen. Bitte warte ein paar Minuten, bevor du es erneut versuchst.",
+        "tooBig": "Hochladen fehlgeschlagen: Die Dateigröße darf max. 20 MB betragen."
+      },
       "firstName": {
         "required": "Vorname benötigt"
       },

--- a/locales/en.json
+++ b/locales/en.json
@@ -821,6 +821,10 @@
         "email": "Invalid email address",
         "required": "Email is required"
       },
+      "file": {
+        "rateLimited": "Upload failed: you have uploaded too many files recently, please wait a few minutes before trying again",
+        "tooBig": "Upload failed: file is too large"
+      },
       "firstName": {
         "required": "First name is required"
       },
@@ -872,7 +876,6 @@
     "saved": "Saved!",
     "unsavedChanges": "Unsaved changes",
     "updated": "Updated",
-    "uploading": "Uploading...",
     "warning": "You should get the user's consent before making updates to this page. All changes you make here will also be visible to the user."
   },
   "homePage": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -826,7 +826,7 @@
       },
       "file": {
         "rateLimited": "Upload failed: you have uploaded too many files recently, please wait a few minutes before trying again",
-        "tooBig": "Upload failed: file is too large"
+        "tooBig": "Upload failed: the file size must be under 20Mb"
       },
       "firstName": {
         "required": "First name is required"

--- a/src/components/forms/AppImageUpload.vue
+++ b/src/components/forms/AppImageUpload.vue
@@ -3,7 +3,7 @@
     <AppLabel v-if="label" :label="label" :required="required" />
     <div class="flex items-start gap-4">
       <div
-        class="flex-0 basis-28 overflow-hidden rounded border border-primary-40 bg-primary-20"
+        class="flex-none basis-28 overflow-hidden rounded border border-primary-40 bg-primary-20 relative"
       >
         <img
           :src="imageUrl"
@@ -12,6 +12,12 @@
           class="h-auto w-full bg-white"
           :class="!imageUrl && 'invisible'"
         />
+        <span
+          v-if="uploading"
+          class="absolute inset-0 bg-black/50 text-white flex items-center justify-center text-xl"
+        >
+          <font-awesome-icon :icon="faCircleNotch" spin />
+        </span>
       </div>
       <div>
         <AppButton is="label" class="mr-2">
@@ -24,24 +30,23 @@
           />
           {{ t('actions.chooseFile') }}
         </AppButton>
-        <span v-if="uploading">
-          <font-awesome-icon :icon="faCircleNotch" spin />
-          {{ t('form.uploading') }}
-        </span>
+        <AppInputError v-if="formError" :message="formError" />
       </div>
     </div>
   </div>
 </template>
 <script lang="ts" setup>
 import useVuelidate from '@vuelidate/core';
-import { sameAs } from '@vuelidate/validators';
-import { ref, toRef, watch } from 'vue';
+import { helpers, requiredIf, sameAs } from '@vuelidate/validators';
+import { computed, ref, toRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import axios from '../../lib/axios';
 import env from '../../env';
 import AppButton from '../button/AppButton.vue';
 import AppLabel from './AppLabel.vue';
 import { faCircleNotch } from '@fortawesome/free-solid-svg-icons';
+import { createUploadFlow } from '../../utils/api/upload';
+import AppInputError from './AppInputError.vue';
 
 const emit = defineEmits(['update:modelValue']);
 const props = defineProps<{
@@ -56,10 +61,20 @@ const { t } = useI18n();
 
 const inputRef = ref<HTMLInputElement>();
 const uploading = ref(false);
-
 const imageUrl = ref(props.modelValue as string);
+const formError = ref('');
 
-useVuelidate({ uploading: { equal: sameAs(false) } }, { uploading });
+const rules = computed(() => ({
+  v: {
+    required: helpers.withMessage(
+      t('form.errors.unknown.required'),
+      requiredIf(!!props.required)
+    ),
+  },
+  uploading: { equal: sameAs(false) },
+}));
+
+useVuelidate(rules, { v: imageUrl, uploading });
 
 watch(toRef(props, 'modelValue'), (newModelValue) => {
   imageUrl.value = newModelValue as string;
@@ -68,31 +83,49 @@ watch(toRef(props, 'modelValue'), (newModelValue) => {
   }
 });
 
-function handleChange() {
+async function handleChange() {
   const file = inputRef.value?.files?.item(0);
-  if (file) {
-    imageUrl.value = URL.createObjectURL(file);
-    uploadFile(file);
-  }
-}
 
-async function uploadFile(file: File) {
+  if (!file) {
+    return;
+  }
+
+  if (file.size > 20 * 1024 * 1024) {
+    formError.value = t('form.errors.file.tooBig');
+    return;
+  }
+
   const data = new FormData();
   data.append('file', file);
 
   uploading.value = true;
+  formError.value = '';
 
-  const resp = await axios.post('/upload/', data, {
-    baseURL: env.appUrl,
-    headers: {
-      'Content-Type': 'multipart/form-data',
-    },
-  });
+  try {
+    const uploadFlow = await createUploadFlow();
 
-  emit(
-    'update:modelValue',
-    `${resp.data.url}?w=${props.width}&h=${props.height}`
-  );
+    const resp = await axios.post('/upload/', data, {
+      baseURL: env.appUrl,
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+      params: {
+        token: uploadFlow.id,
+      },
+    });
+
+    imageUrl.value = URL.createObjectURL(file);
+
+    emit(
+      'update:modelValue',
+      `${resp.data.url}?w=${props.width}&h=${props.height}`
+    );
+  } catch (err) {
+    formError.value =
+      axios.isAxiosError(err) && err.response?.status === 429
+        ? t('form.errors.file.rateLimited')
+        : t('form.errorMessages.generic');
+  }
 
   uploading.value = false;
 }

--- a/src/utils/api/api.interface.ts
+++ b/src/utils/api/api.interface.ts
@@ -520,3 +520,8 @@ export interface GetEmailData {
 }
 
 export type UpdateEmailData = GetEmailData;
+
+export interface GetUploadFlowData {
+  id: string;
+  ipAddress: string;
+}

--- a/src/utils/api/upload.ts
+++ b/src/utils/api/upload.ts
@@ -1,0 +1,8 @@
+import axios from '../../lib/axios';
+
+import { GetUploadFlowData, Serial } from './api.interface';
+
+export async function createUploadFlow(): Promise<GetUploadFlowData> {
+  const { data } = await axios.post<Serial<GetUploadFlowData>>('/upload');
+  return data;
+}


### PR DESCRIPTION
This PR uses the new upload API to authenticate uploads, and also handles errors such as rate limiting or file too large more gracefully

### Screenshots

![image](https://github.com/beabee-communityrm/beabee-frontend/assets/2084823/1bfc2ee9-b3f2-4be8-8bf3-7a50bed4470e)

## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `npm run check` and addressed any problems
- [x] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
