### PR TITLE
chore: remove gzip directives in favour of global ones

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -6,9 +6,6 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
-  gzip on;
-  gzip_vary on;
-
   location / {
     expires -1;
     add_header Cache-Control 'no-cache, no-store';


### PR DESCRIPTION
Remove gzip from here in favour of it being enabled in the main router, see https://github.com/beabee-communityrm/beabee-router/pull/10