### PR TITLE
fix: update FormIO to fix non-ascii chars in key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "body-scroll-lock": "^4.0.0-beta.0",
         "color2k": "^2.0.3",
         "date-fns": "^2.30.0",
-        "formiojs": "npm:@beabee/formiojs@^4.15.8",
+        "formiojs": "npm:@beabee/formiojs@^4.15.9",
         "iframe-resizer": "^4.3.9",
         "maplibre-gl": "^3.6.2",
         "mitt": "^3.0.1",
@@ -3362,9 +3362,9 @@
     },
     "node_modules/formiojs": {
       "name": "@beabee/formiojs",
-      "version": "4.15.8",
-      "resolved": "https://registry.npmjs.org/@beabee/formiojs/-/formiojs-4.15.8.tgz",
-      "integrity": "sha512-as/vXyGb6PFzt/KKJhXIejN9SYVAB1gDdPs/UrK0rKcWD8zVP7iBbfrL2TDxJkEwQaYXpZ7N9ft9xGLPpRcIlw==",
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/@beabee/formiojs/-/formiojs-4.15.9.tgz",
+      "integrity": "sha512-etaKGqY+tnR3BK/+rd+PBMk7phmozuP6qY8bXTLBxP2R5cffaU+sSdY5LdjBCtAIT909TwBLGef2B07CK8ZKzQ==",
       "dependencies": {
         "@formio/bootstrap3": "2.12.3",
         "@formio/choices.js": "10.2.0",
@@ -3402,14 +3402,6 @@
         "tippy.js": "^6.3.7",
         "uuid": "^9.0.0",
         "vanilla-picker": "^2.12.1"
-      }
-    },
-    "node_modules/formiojs/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/fraction.js": {
@@ -6858,7 +6850,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "body-scroll-lock": "^4.0.0-beta.0",
     "color2k": "^2.0.3",
     "date-fns": "^2.30.0",
-    "formiojs": "npm:@beabee/formiojs@^4.15.8",
+    "formiojs": "npm:@beabee/formiojs@^4.15.9",
     "iframe-resizer": "^4.3.9",
     "maplibre-gl": "^3.6.2",
     "mitt": "^3.0.1",
@@ -87,6 +87,6 @@
     "vue-tsc": "^1.8.25"
   },
   "overrides": {
-    "formiojs": "npm:@beabee/formiojs@^4.15.8"
+    "formiojs": "npm:@beabee/formiojs@^4.15.9"
   }
 }


### PR DESCRIPTION
Non-ascii characters were being used for the component key, this PR updates our formio.js lib to fix this (see https://github.com/beabee-communityrm/formio.js/commit/fc8cfedca48361079bcab7b442244def10d0c0cd)

![image](https://github.com/beabee-communityrm/beabee-frontend/assets/2084823/215fc884-2838-4a57-b87f-4aad9cf63b53)
