### PR TITLE
feat!: Use new stripe db entry

### DIFF
--- a/src/components/contribution/Contribution.vue
+++ b/src/components/contribution/Contribution.vue
@@ -72,7 +72,7 @@ const props = withDefaults(
 
 const { t } = useI18n();
 
-const fee = computed(() => calcPaymentFee(props, props.content.stripeCountry));
+const fee = computed(() => calcPaymentFee(props, props.content.stripe.country));
 
 const emit = defineEmits([
   'update:amount',

--- a/src/components/contribution/contribution.interface.ts
+++ b/src/components/contribution/contribution.interface.ts
@@ -1,4 +1,4 @@
-import type { ContentJoinData } from '@type';
+import type { ContentJoinData, ContentStripeData } from '@type';
 
 export type ContributionContent = Pick<
   ContentJoinData,
@@ -8,6 +8,6 @@ export type ContributionContent = Pick<
   | 'showAbsorbFee'
   | 'periods'
   | 'paymentMethods'
-  | 'stripePublicKey'
-  | 'stripeCountry'
->;
+> & {
+  stripe: Pick<ContentStripeData, 'publicKey' | 'country'>;
+};

--- a/src/components/pages/join/JoinForm.vue
+++ b/src/components/pages/join/JoinForm.vue
@@ -17,7 +17,7 @@
         v-model:period="signUpData.period"
         v-model:payFee="signUpData.payFee"
         v-model:paymentMethod="signUpData.paymentMethod"
-        :content="joinContent"
+        :content="{ ...joinContent, stripe: stripeContent }"
         :disabled="signUpData.noContribution"
       >
         <AppCheckbox
@@ -67,17 +67,20 @@ import AppCheckbox from '@components/forms/AppCheckbox.vue';
 import AppForm from '@components/forms/AppForm.vue';
 import AuthBox from '@components/AuthBox.vue';
 
-import type { ContentJoinData } from '@type';
+import type { ContentJoinData, ContentStripeData } from '@type';
 
 const props = defineProps<{
   joinContent: ContentJoinData;
+  stripeContent: ContentStripeData;
   preview?: boolean;
   onSubmit?: () => Promise<void>;
 }>();
 
 const { t } = useI18n();
 
-const { signUpData, signUpDescription } = useJoin(toRef(props, 'joinContent'));
+const { signUpData, signUpDescription } = useJoin(
+  toRef(props, 'stripeContent')
+);
 
 const buttonText = computed(() => {
   return signUpData.noContribution

--- a/src/components/pages/join/use-join.ts
+++ b/src/components/pages/join/use-join.ts
@@ -7,7 +7,7 @@ import { reactive, computed, type Ref } from 'vue';
 
 import i18n from '@lib/i18n';
 
-import type { ContentJoinData } from '@type';
+import type { ContentStripeData } from '@type';
 
 const { n, t } = i18n.global;
 
@@ -22,12 +22,12 @@ const signUpData = reactive({
   paymentMethod: PaymentMethod.StripeCard,
 });
 
-export function useJoin(content: Ref<ContentJoinData>) {
+export function useJoin(content: Ref<ContentStripeData>) {
   const signUpDescription = computed(() => {
     const totalAmount =
       signUpData.amount +
       (signUpData.payFee
-        ? calcPaymentFee(signUpData, content.value.stripeCountry)
+        ? calcPaymentFee(signUpData, content.value.country)
         : 0);
 
     return {

--- a/src/components/pages/profile/contribution/UpdateContribution.vue
+++ b/src/components/pages/profile/contribution/UpdateContribution.vue
@@ -76,7 +76,7 @@
       </AppHeading>
       <StripePayment
         :client-secret="stripeClientSecret"
-        :public-key="content.stripePublicKey"
+        :public-key="content.stripe.publicKey"
         :email="email"
         :return-url="startContributionCompleteUrl"
         @loaded="onStripeLoaded"

--- a/src/pages/admin/membership-builder/index.vue
+++ b/src/pages/admin/membership-builder/index.vue
@@ -90,7 +90,11 @@ meta:
       </AppForm>
     </template>
     <template #col2>
-      <JoinForm :join-content="joinContent" preview />
+      <JoinForm
+        :join-content="joinContent"
+        :stripe-content="stripeContent!"
+        preview
+      />
     </template>
   </App2ColGrid>
 </template>
@@ -117,9 +121,10 @@ import { fetchContent, updateContent } from '@utils/api/content';
 
 import { generalContent } from '@store';
 
-import type { ContentJoinData } from '@type';
+import type { ContentJoinData, ContentStripeData } from '@type';
 
 const joinContent = ref<ContentJoinData>();
+const stripeContent = ref<ContentStripeData>();
 const backgroundUrl = ref('');
 
 const { n, t } = useI18n();
@@ -175,6 +180,7 @@ async function handleUpdate() {
 
 onBeforeMount(async () => {
   joinContent.value = await fetchContent('join');
+  stripeContent.value = await fetchContent('stripe');
   backgroundUrl.value = generalContent.value.backgroundUrl || '';
 });
 </script>

--- a/src/pages/admin/settings/index.vue
+++ b/src/pages/admin/settings/index.vue
@@ -201,7 +201,7 @@ import { fetchContent, updateContent } from '@utils/api/content';
 
 import { generalContent as storeGeneralContent } from '@store';
 
-import type { ContentShareData, ContentJoinData } from '@type';
+import type { ContentShareData, ContentStripeData } from '@type';
 import { localeItems } from '@lib/i18n';
 
 const { t } = useI18n();
@@ -219,7 +219,7 @@ const footerData = reactive({
   footerLinks: [] as { text: string; url: string }[],
 });
 
-const paymentData = ref<Pick<ContentJoinData, 'taxRateEnabled' | 'taxRate'>>({
+const paymentData = ref<Pick<ContentStripeData, 'taxRateEnabled' | 'taxRate'>>({
   taxRateEnabled: false,
   taxRate: 7,
 });
@@ -246,7 +246,7 @@ async function handleSaveFooter() {
   storeGeneralContent.value = await updateContent('general', footerData);
 }
 async function handleSavePayment() {
-  await updateContent('join', paymentData.value);
+  await updateContent('stripe', paymentData.value);
 }
 
 onBeforeMount(async () => {
@@ -263,10 +263,10 @@ onBeforeMount(async () => {
 
   shareContent.value = await fetchContent('share');
 
-  const joinContent = await fetchContent('join');
+  const stripeContent = await fetchContent('stripe');
   paymentData.value = {
-    taxRateEnabled: joinContent.taxRateEnabled,
-    taxRate: joinContent.taxRate,
+    taxRateEnabled: stripeContent.taxRateEnabled,
+    taxRate: stripeContent.taxRate,
   };
 });
 </script>

--- a/src/pages/join/index.vue
+++ b/src/pages/join/index.vue
@@ -11,6 +11,7 @@ meta:
   <JoinForm
     v-if="!stripeClientSecret"
     :join-content="joinContent"
+    :stripe-content="stripeContent"
     @submit.prevent="submitSignUp"
   />
 
@@ -44,7 +45,7 @@ meta:
 
     <StripePayment
       :client-secret="stripeClientSecret"
-      :public-key="joinContent.stripePublicKey"
+      :public-key="stripeContent.publicKey"
       :email="signUpData.email"
       :return-url="completeUrl"
       show-name-fields
@@ -70,7 +71,7 @@ import { signUp, completeUrl } from '@utils/api/signup';
 
 import { generalContent } from '@store';
 
-import type { ContentJoinData } from '@type';
+import type { ContentJoinData, ContentStripeData } from '@type';
 
 const { t } = useI18n();
 
@@ -89,13 +90,16 @@ const joinContent = ref<ContentJoinData>({
   subtitle: '',
   title: '',
   paymentMethods: [],
-  stripePublicKey: '',
-  stripeCountry: 'eu',
+});
+
+const stripeContent = ref<ContentStripeData>({
+  publicKey: '',
+  country: 'eu',
   taxRateEnabled: false,
   taxRate: 7,
 });
 
-const { signUpData, signUpDescription } = useJoin(joinContent);
+const { signUpData, signUpDescription } = useJoin(stripeContent);
 
 async function submitSignUp() {
   const data = await signUp(signUpData);
@@ -112,6 +116,8 @@ onBeforeMount(async () => {
   stripeClientSecret.value = '';
 
   joinContent.value = await fetchContent('join');
+
+  stripeContent.value = await fetchContent('stripe');
 
   signUpData.amount =
     (route.query.amount && Number(route.query.amount)) ||

--- a/src/pages/profile/contribution/index.vue
+++ b/src/pages/profile/contribution/index.vue
@@ -47,7 +47,7 @@ meta:
         class="mb-7 md:mb-9"
         :email="email"
         :payment-source="contribution.paymentSource"
-        :stripe-public-key="content.stripePublicKey"
+        :stripe-public-key="content.stripe.publicKey"
       />
       <ContactCancelContribution
         id="me"
@@ -106,8 +106,10 @@ const content = ref<ContributionContent>({
   periods: [],
   showAbsorbFee: true,
   paymentMethods: [PaymentMethod.StripeCard],
-  stripePublicKey: '',
-  stripeCountry: 'eu',
+  stripe: {
+    publicKey: '',
+    country: 'eu',
+  },
 });
 
 const email = computed(() =>
@@ -122,7 +124,13 @@ const contribution = ref<ContributionInfo>({
 
 onBeforeMount(async () => {
   isIniting.value = true;
-  content.value = await fetchContent('join');
+  const joinContent = await fetchContent('join');
+  const stripeContent = await fetchContent('stripe');
+
+  content.value = {
+    ...joinContent,
+    stripe: stripeContent,
+  };
   contribution.value = await fetchContribution();
   isIniting.value = false;
 });

--- a/src/type/content-id.ts
+++ b/src/type/content-id.ts
@@ -5,4 +5,5 @@ export type ContentId =
   | 'general'
   | 'contacts'
   | 'email'
-  | 'share';
+  | 'share'
+  | 'stripe';

--- a/src/type/content-join-data.ts
+++ b/src/type/content-join-data.ts
@@ -1,8 +1,4 @@
-import type {
-  ContributionPeriod,
-  PaymentMethod,
-  StripeFeeCountry,
-} from '@beabee/beabee-common';
+import type { ContributionPeriod, PaymentMethod } from '@beabee/beabee-common';
 
 import type { ContentJoinPeriodData } from './index';
 
@@ -16,8 +12,4 @@ export interface ContentJoinData {
   showAbsorbFee: boolean;
   showNoContribution: boolean;
   paymentMethods: PaymentMethod[];
-  stripePublicKey: string;
-  stripeCountry: StripeFeeCountry;
-  taxRateEnabled: boolean;
-  taxRate: number;
 }

--- a/src/type/content-stripe-data.ts
+++ b/src/type/content-stripe-data.ts
@@ -1,0 +1,8 @@
+import type { StripeFeeCountry } from '@beabee/beabee-common';
+
+export interface ContentStripeData {
+  publicKey: string;
+  country: StripeFeeCountry;
+  taxRateEnabled: boolean;
+  taxRate: number;
+}

--- a/src/type/content.ts
+++ b/src/type/content.ts
@@ -6,6 +6,7 @@ import type {
   ContentJoinSetupData,
   ContentProfileData,
   ContentShareData,
+  ContentStripeData,
   ContentId,
 } from '@type';
 
@@ -23,4 +24,6 @@ export type Content<Id extends ContentId> = Id extends 'join'
             ? ContentEmailData
             : Id extends 'share'
               ? ContentShareData
-              : never;
+              : Id extends 'stripe'
+                ? ContentStripeData
+                : never;

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -31,6 +31,7 @@ export * from './content-join-period-data';
 export * from './content-join-setup-data';
 export * from './content-profile-data';
 export * from './content-share-data';
+export * from './content-stripe-data';
 export * from './content';
 export * from './contribution-info';
 export * from './create-api-key-data';


### PR DESCRIPTION
I wasn't sure if it's ok to create a new database entry for the stripe data, so another PR, if that's all ok I can merge all 3 PR's into a common one.

PR's:
* #575 - Base PR to add the tax rate to the frontend
* #579 - Use the new stripe tax object and moved the settings from membership builder to general settings
* #585 - Use new stripe db entry / controller from the backend (this PR)