### PR TITLE
feat: hide draft payments in payment history

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -545,6 +545,7 @@
     "pageCount": "Seite {pageNumber} von {pageTotal}",
     "paymentStatus": {
       "cancelled": "Gekündigt",
+      "draft": "Entwurf",
       "failed": "Fehlgeschlagen",
       "pending": "In Bearbeitung",
       "successful": "Erfolgreich"

--- a/locales/de@easy.json
+++ b/locales/de@easy.json
@@ -139,7 +139,9 @@
     "loading": "Der Computer arbeitet.",
     "newsletterStatus": {},
     "noResults": "Der Computer hat keine Ergebnisse gefunden.",
-    "paymentStatus": {},
+    "paymentStatus": {
+      "draft": "Hier ist ein erster Vorschlag."
+    },
     "role": {},
     "selectNone": "keine",
     "selectOne": "Hier kannst du ein Bild / eine Unterschrift / … aus-suchen",

--- a/locales/de@informal.json
+++ b/locales/de@informal.json
@@ -545,6 +545,7 @@
     "pageCount": "Seite {pageNumber} von {pageTotal}",
     "paymentStatus": {
       "cancelled": "Gekündigt",
+      "draft": "Entwurf",
       "failed": "Fehlgeschlagen",
       "pending": "In Bearbeitung",
       "successful": "Erfolgreich"

--- a/locales/en.json
+++ b/locales/en.json
@@ -549,6 +549,7 @@
     "pageCount": "Page {pageNumber} out of {pageTotal}",
     "paymentStatus": {
       "cancelled": "Cancelled",
+      "draft": "Draft",
       "failed": "Failed",
       "pending": "Pending",
       "successful": "Successful"

--- a/locales/it.json
+++ b/locales/it.json
@@ -160,6 +160,7 @@
     "pageCount": "Pagina {pageNumber} di {pageTotal}",
     "paymentStatus": {
       "cancelled": "Cancellato",
+      "draft": "Bozza",
       "failed": "Errore",
       "pending": "In attesa",
       "successful": "Riuscito"

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -144,7 +144,9 @@
     "loading": "Ladt...",
     "newsletterStatus": {},
     "noResults": "Geen resultaten gevonden",
-    "paymentStatus": {},
+    "paymentStatus": {
+      "draft": "Ontwerp"
+    },
     "role": {},
     "selectNone": "Geen",
     "selectOne": "Kiies er één",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -342,6 +342,7 @@
     "pageCount": "Página {pageNumber} de {pageTotal}",
     "paymentStatus": {
       "cancelled": "Cancelado",
+      "draft": "Rascunho",
       "failed": "Falhado",
       "pending": "A aguardar",
       "successful": "Sucesso"

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -313,6 +313,7 @@
     "pageCount": "Страница {pageNumber} из {pageTotal}",
     "paymentStatus": {
       "cancelled": "Отменён",
+      "draft": "Черновик",
       "failed": "Ошибка",
       "pending": "В работе",
       "successful": "Успех"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.0",
       "dependencies": {
         "@appsignal/javascript": "^1.3.28",
-        "@beabee/beabee-common": "^0.20.3",
+        "@beabee/beabee-common": "^0.20.7",
         "@captchafox/vue": "^1.1.0",
         "@fontsource/fira-sans": "^5.0.18",
         "@fontsource/fira-sans-condensed": "^5.0.8",
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@beabee/beabee-common": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-0.20.3.tgz",
-      "integrity": "sha512-3EDuDdWdVQvr9yZtIzKM37Gv5rwdyJK9q6XtgK0/JY5i7o/XRoCsqsfnEVMs52N1NQcnru8x+pwJnH4hXf1PbA==",
+      "version": "0.20.7",
+      "resolved": "https://registry.npmjs.org/@beabee/beabee-common/-/beabee-common-0.20.7.tgz",
+      "integrity": "sha512-zoupoEsxkb/PGzZ3CuGEhaobN3rJmz3U9VABtQc1+a8BwsPQDmOPK5XmQacvzTtiBd72nSngqsONDivIPrcLuQ==",
       "dependencies": {
         "date-fns": "^3.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@appsignal/javascript": "^1.3.28",
-    "@beabee/beabee-common": "^0.20.3",
+    "@beabee/beabee-common": "^0.20.7",
     "@captchafox/vue": "^1.1.0",
     "@fontsource/fira-sans": "^5.0.18",
     "@fontsource/fira-sans-condensed": "^5.0.8",

--- a/src/components/contact/ContactPaymentsHistory.vue
+++ b/src/components/contact/ContactPaymentsHistory.vue
@@ -13,8 +13,8 @@
         {{ formatLocale(value, 'PPP') }}
       </template>
       <template #value-amount="{ value, item }">
-        <span class="mr-3">
-          {{ getStatusText(item) }}
+        <span v-if="item.status !== PaymentStatus.Successful" class="mr-3">
+          {{ t('common.paymentStatus.' + item.status) }}
         </span>
         <b>{{ n(value, 'currency') }}</b>
       </template>
@@ -79,20 +79,10 @@ function getRowClass(item: GetPaymentData) {
     case PaymentStatus.Failed:
       return 'text-danger';
     case PaymentStatus.Pending:
+    case PaymentStatus.Draft:
       return 'text-body-60';
     default:
       return '';
-  }
-}
-
-function getStatusText(item: GetPaymentData) {
-  switch (item.status) {
-    case PaymentStatus.Cancelled:
-      return t('common.paymentStatus.cancelled');
-    case PaymentStatus.Failed:
-      return t('common.paymentStatus.failed');
-    case PaymentStatus.Pending:
-      return t('common.paymentStatus.pending');
   }
 }
 

--- a/src/components/contact/ContactPaymentsHistory.vue
+++ b/src/components/contact/ContactPaymentsHistory.vue
@@ -48,7 +48,7 @@ import AppHeading from '@components/AppHeading.vue';
 import { formatLocale } from '@utils/dates';
 import { fetchPayments } from '@utils/api/contact';
 
-import type { GetPaymentData } from '@type';
+import type { GetPaymentData, GetPaymentsQuery } from '@type';
 
 const { t, n } = useI18n();
 
@@ -97,11 +97,15 @@ function getStatusText(item: GetPaymentData) {
 }
 
 watchEffect(async () => {
-  const query = {
+  const query: GetPaymentsQuery = {
     offset: currentPage.value * pageSize,
     limit: pageSize,
     sort: 'chargeDate',
     order: SortType.Desc,
+    rules: {
+      condition: 'AND',
+      rules: [{ field: 'status', operator: 'not_equal', value: ['draft'] }],
+    },
   };
   paymentsHistoryTable.value = await fetchPayments(props.id, query);
 });

--- a/src/components/pages/admin/payments.interface.ts
+++ b/src/components/pages/admin/payments.interface.ts
@@ -74,8 +74,9 @@ export const filterItems = computed<FilterItems<PaymentFilterName>>(() => ({
   contact: withLabel(paymentFilters.contact, t('payments.data.contact')),
   amount: withLabel(paymentFilters.amount, t('payments.data.amount')),
   status: withLabel(paymentFilters.status, t('payments.data.status'), {
-    successful: t('common.paymentStatus.successful'),
+    draft: t('common.paymentStatus.draft'),
     pending: t('common.paymentStatus.pending'),
+    successful: t('common.paymentStatus.successful'),
     failed: t('common.paymentStatus.failed'),
     cancelled: t('common.paymentStatus.cancelled'),
   }),

--- a/src/components/payment/PaymentStatus.vue
+++ b/src/components/payment/PaymentStatus.vue
@@ -10,6 +10,7 @@ import { PaymentStatus } from '@beabee/beabee-common';
 import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
 const color = {
+  draft: 'text-body-60',
   pending: 'text-body-60',
   successful: 'text-success',
   cancelled: 'text-danger',

--- a/src/lib/i18n-config.json
+++ b/src/lib/i18n-config.json
@@ -5,12 +5,6 @@
     "displayName": "English",
     "adminLocale": "en"
   },
-  "it": {
-    "baseLocale": "it",
-    "name": "Italiano",
-    "displayName": "Italiano",
-    "adminLocale": "en"
-  },
   "de": {
     "baseLocale": "de",
     "name": "Deutsch (formal)",
@@ -22,6 +16,12 @@
     "name": "Deutsch (informal)",
     "displayName": "Deutsch",
     "adminLocale": "de@informal"
+  },
+  "it": {
+    "baseLocale": "it",
+    "name": "Italiano",
+    "displayName": "Italiano",
+    "adminLocale": "en"
   },
   "ru": {
     "baseLocale": "ru",


### PR DESCRIPTION
Update payment history to support draft styling, but hide all the draft payments for now

### Screenshots

Before (no draft styling)
![image](https://github.com/beabee-communityrm/beabee-frontend/assets/2084823/3ca5cf88-ed7b-45c9-a9ca-deeefd97c5b0)

After (hide draft payments)
![image](https://github.com/beabee-communityrm/beabee-frontend/assets/2084823/622b4138-ef1b-4857-a850-9fb0c0bd4c31)


## Checklist before requesting a review

- [x] Done a self-review of my code
- [x] Run `npm run check` and addressed any problems
- [ ] PR doesn't have merge conflicts

## Checklist before merging

- [x] Translations for all new i18n strings
